### PR TITLE
Fix a couple of runtime problems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__init__.py
+__pycache__
+.gdb_history
+*.root

--- a/Framework/bin/produceNtuple.cc
+++ b/Framework/bin/produceNtuple.cc
@@ -234,7 +234,7 @@ std::cout << "break-point 21 reached" << std::endl;
   edmplugin::PluginManager::Config config;
   edmplugin::PluginManager::configure(edmplugin::standard::config());
   edm::VParameterSet cfg_writers = cfg_produceNtuple.getParameterSetVector("writerPlugins");
-  std::vector<WriterBase*> writers;
+  std::vector<std::unique_ptr<WriterBase>> writers;
   for ( auto cfg_writer : cfg_writers )
   {
 std::cout << "break-point 21.1 reached" << std::endl;
@@ -245,20 +245,21 @@ std::cout << "pluginType = " << pluginType << std::endl;
     cfg_writer.addParameter<std::string>("process", process);
     cfg_writer.addParameter<bool>("isMC", isMC);
 std::cout << "break-point 21.2 reached" << std::endl;
-    WriterBase* writer = WriterPluginFactory::get()->create(pluginType, cfg_writer).get();
+    std::unique_ptr<WriterBase> writer = WriterPluginFactory::get()->create(pluginType, cfg_writer);
 std::cout << "break-point 21.3 reached" << std::endl;
     writer->registerReaders(inputTree);
 std::cout << "break-point 21.4 reached" << std::endl;
     writer->setBranches(outputTree);
 std::cout << "break-point 21.5 reached" << std::endl;
-    writers.push_back(writer);
+    writers.push_back(std::move(writer));
 std::cout << "break-point 21.6 reached" << std::endl;
   }
 std::cout << "break-point 22 reached" << std::endl;
   int analyzedEntries = 0;
   TH1* histogram_analyzedEntries = fs.make<TH1D>("analyzedEntries", "analyzedEntries", 1, -0.5, +0.5);
-  for ( auto central_or_shift : systematic_shifts )
+  for ( const auto & central_or_shift : systematic_shifts )
   {
+    std::cout << "central_or_shift = " << central_or_shift << '\n';
 std::cout << "break-point 23 reached" << std::endl;
     inputTree->reset();
 std::cout << "break-point 24 reached" << std::endl;
@@ -437,7 +438,7 @@ std::cout << "break-point 31 reached" << std::endl;
         }
       }
 std::cout << "break-point 32 reached" << std::endl;
-      for ( auto writer : writers )
+      for ( auto & writer : writers )
       {
         writer->set_central_or_shift(central_or_shift);
         writer->write(event, evtWeightRecorder);
@@ -486,9 +487,9 @@ std::cout << "break-point 39 reached" << std::endl;
   delete jetToHadTauFakeRateInterface;
   delete btagSFRatioInterface;
 std::cout << "break-point 40 reached" << std::endl;
-  for ( auto writer : writers )
+  for ( auto & writer : writers )
   {
-    delete writer;
+    writer.reset(nullptr);
   }
 std::cout << "break-point 41 reached" << std::endl;
   delete inputTree;

--- a/Framework/test/produceNtuple_cfg.py
+++ b/Framework/test/produceNtuple_cfg.py
@@ -20,7 +20,7 @@ process = cms.PSet()
 
 process.fwliteInput = cms.PSet(
     fileNames = cms.vstring(),
-    maxEvents = cms.int32(-1),
+    maxEvents = cms.int32(100),
     outputEvery = cms.uint32(100000)
 )
 
@@ -151,9 +151,9 @@ process.produceNtuple = cms.PSet(
     writerPlugins = cms.VPSet(       
 ##        writers_fakeableHadTaus,
 ##        writers_fakeableLeptons,
-        writers_genPhotonFilter,
+##        writers_genPhotonFilter,
 ##        writers_lowMassLeptonPairVeto,
-##        writers_met,
+        writers_met,
 ##        writers_metFilters,
 ##        writers_process,
 ##        writers_run_lumi_event,

--- a/Objects/src/EventInfo.cc
+++ b/Objects/src/EventInfo.cc
@@ -65,7 +65,7 @@ EventInfo::EventInfo()
 EventInfo::EventInfo(const AnalysisConfig & analysisConfig)
   : EventInfo()
 {
-  analysisConfig_ = &analysisConfig; 
+  analysisConfig_ = &analysisConfig;
   process_string_ = analysisConfig.process();
   std::cout << "<EventInfo::EventInfo()>: process = '" << process_string_ << "'\n";
   int checksum = 0;
@@ -75,8 +75,8 @@ EventInfo::EventInfo(const AnalysisConfig & analysisConfig)
   if ( !(checksum == 0 || (checksum == 1 && analysisConfig_->isMC())) )
     throw cmsException(this, __func__, __LINE__)
       << "Invalid combination of Configuration parameters:\n" 
-      << " isMC = " << analysisConfig_->isMC() << "\n" 
-      << " isMC_H = " << analysisConfig_->isMC_H() << "\n"  
+      << " isMC = " << analysisConfig_->isMC() << "\n"
+      << " isMC_H = " << analysisConfig_->isMC_H() << "\n"
       << " isMC_HH = " << analysisConfig_->isMC_HH() << "\n";
 }
 

--- a/Readers/interface/EventInfoReader.h
+++ b/Readers/interface/EventInfoReader.h
@@ -6,6 +6,7 @@
 // forward declarations
 class TTree;
 class EventInfo;
+class AnalysisConfig;
 
 class EventInfoReader : public ReaderBase
 {
@@ -46,6 +47,7 @@ class EventInfoReader : public ReaderBase
   bool read_genHiggsDecayMode_;
   bool read_puWeight_;
 
+  const AnalysisConfig * analysisConfig_;
   EventInfo * info_;
 
   std::string branchName_topPtRwgt;

--- a/Readers/src/EventInfoReader.cc
+++ b/Readers/src/EventInfoReader.cc
@@ -1,6 +1,5 @@
 #include "TallinnNtupleProducer/Readers/interface/EventInfoReader.h"
 
-#include "TallinnNtupleProducer/CommonTools/interface/AnalysisConfig.h"       // AnalysisConfig
 #include "TallinnNtupleProducer/CommonTools/interface/get_htxs_binning.h"     // get_htxs_binning()
 #include "TallinnNtupleProducer/CommonTools/interface/sysUncertOptions.h"     // getBranchName_pileup()
 #include "TallinnNtupleProducer/Objects/interface/EventInfo.h"                // EventInfo
@@ -15,7 +14,8 @@ EventInfoReader::EventInfoReader(const edm::ParameterSet & cfg)
   : ReaderBase(cfg)
   , read_genHiggsDecayMode_(true)
   , read_puWeight_(true)
-  , info_(nullptr)
+  , analysisConfig_(new AnalysisConfig("produceNtuple", cfg))
+  , info_(new EventInfo(*analysisConfig_))
   , branchName_run("run")
   , branchName_lumi("luminosityBlock")
   , branchName_event("event")
@@ -28,16 +28,13 @@ EventInfoReader::EventInfoReader(const edm::ParameterSet & cfg)
   , branchName_htxs_pt("HTXS_Higgs_pt")
   , branchName_htxs_y("HTXS_Higgs_y")
 {
-  std::string analysis = "produceNtuple";
-  AnalysisConfig analysisConfig(analysis, cfg);
-  info_ = new EventInfo(analysisConfig);
   const bool isMC = cfg.getParameter<bool>("isMC");
   if ( isMC )
   {
     const double ref_genWeight = cfg.getParameter<double>("ref_genWeight");
     info_->set_refGetWeight(ref_genWeight);
   }
-  const bool isMC_ttH = analysisConfig.isMC_ttH();
+  const bool isMC_ttH = analysisConfig_->isMC_ttH();
   const std::vector<std::pair<std::string, int>> evt_htxs_binning = get_htxs_binning(isMC_ttH);
   info_->read_htxs(!evt_htxs_binning.empty());
 }

--- a/Writers/interface/WriterBase.h
+++ b/Writers/interface/WriterBase.h
@@ -32,7 +32,7 @@ class WriterBase
    */
   virtual
   void
-  setBranches(TTree * outputTree);
+  setBranches(TTree * outputTree) = 0;
 
   /**
    * @brief Switch branches to those for the central value or for systematic shifts.

--- a/Writers/src/WriterBase.cc
+++ b/Writers/src/WriterBase.cc
@@ -15,14 +15,6 @@ WriterBase::registerReaders(TTreeWrapper * inputTree)
 {}
 
 void
-WriterBase::setBranches(TTree * outputTree)
-{
-  // CV: this function should never be called, 
-  //     as it is supposed to the overwritten by all derrived classes !!
-  assert(0);
-}
-
-void
 WriterBase::set_central_or_shift(const std::string & central_or_shift) const
 {
   current_central_or_shift_ = central_or_shift;


### PR DESCRIPTION
The main problem that triggered this investigation was this line:
https://github.com/HEP-KBFI/TallinnNtupleProducer/blob/ed53fc8e90e8df7959e21d1cdd0a63066d14c60b/Framework/bin/produceNtuple.cc#L248
The `writer` object was `nullptr` which is why the 2nd line that follows caused the segmentation violation. I'm not entirely sure how the ownership works here, but the C++ documentation [says](https://en.cppreference.com/w/cpp/memory/unique_ptr/get) that if the object is not owned then the last `get()` call returns a `nullptr`. In any case, promoting the `writer` variable to `unique_ptr` seems to work.

The second error I got was related to the instantiation of `EventInfo` object in `EventInfoReader`: the `AnalysisConfig` object is created on stack, then its address is passed to `EventInfo` and then the `AnalysisConfig` object goes out of scope, thus rendering its pointer invalid. The solution is to move `AnalysisConfig` to heap.

The third error was caused by reading a collection that does not exist in the input Ntuple (GenPhotonCandidates). Swapped `writers_genPhotonFilter` for `writers_met` in the cfg file. Also limited the number of events to 100 -- just for testing.

I then got a fourth error that was related to lumiscale weights. I hacked the `EvtWeightRecorder` to see if I get any more errors -- and I unfortunately did, so that's where I stopped. I'm not going to push the hack I did here, but the rest of the changes in this PR should be solid.

Also, added `.gitignroe`, since there were too many artifacts created by `scram` after compiling the code, which we don't want to accidentally push to the repo.