### PR TITLE
Set jet btag score

### DIFF
--- a/Objects/interface/RecoLepton.h
+++ b/Objects/interface/RecoLepton.h
@@ -139,6 +139,9 @@ class RecoLepton : public ChargedParticle
   const GenPhoton * genPhoton() const;
   const GenJet * genJet() const;
 
+  void
+  setjetBtagCSV(double btag);
+
   bool hasJetBtagCSV(Btag btag) const;
 
   bool isGenMatched(bool requireChargeMatch) const;

--- a/Objects/interface/RecoLepton.h
+++ b/Objects/interface/RecoLepton.h
@@ -140,7 +140,7 @@ class RecoLepton : public ChargedParticle
   const GenJet * genJet() const;
 
   void
-  setjetBtagCSV(double btag);
+  setjetBtagCSV(double btag, Btag btagAlgo=Btag::kDeepJet);
 
   bool hasJetBtagCSV(Btag btag) const;
 

--- a/Objects/src/RecoLepton.cc
+++ b/Objects/src/RecoLepton.cc
@@ -232,6 +232,12 @@ RecoLepton::jetPtRel() const
   return jetPtRel_;
 }
 
+void
+RecoLepton::setjetBtagCSV(double btag)
+{
+  assocJetBtagCSVs_[Btag::kDeepJet] = btag;
+}
+
 Double_t
 RecoLepton::jetBtagCSV(Btag btag) const
 {

--- a/Objects/src/RecoLepton.cc
+++ b/Objects/src/RecoLepton.cc
@@ -233,9 +233,9 @@ RecoLepton::jetPtRel() const
 }
 
 void
-RecoLepton::setjetBtagCSV(double btag)
+RecoLepton::setjetBtagCSV(double btagscore, Btag btagAlgo)
 {
-  assocJetBtagCSVs_[Btag::kDeepJet] = btag;
+  assocJetBtagCSVs_[btagAlgo] = btagscore;
 }
 
 Double_t

--- a/Readers/interface/setJetBtagScore.h
+++ b/Readers/interface/setJetBtagScore.h
@@ -13,21 +13,17 @@ template <typename T>
 void
 setJetBtagScore(std::vector<T> & particles, const std::vector<RecoJetAK4> & jets)
 {
-  Int_t njets = jets.size();
+  const Int_t njets = jets.size();
 
   for ( T & particle : particles )
   {
-    T * particlePtr = &particle;
-    Int_t jetIdx = particlePtr->jetIdx();
-    if ( jetIdx >=0 &&  jetIdx <njets)
+    const Int_t jetIdx = particle.jetIdx();
+    double btag = ( jetIdx >=0 &&  jetIdx <njets ) ? jets.at(jetIdx).BtagCSV() : -1;
+    if(std::isnan(btag))
     {
-      double btag = jets.at(jetIdx).BtagCSV();
-      particlePtr->setjetBtagCSV(btag);
+      btag = -2;
     }
-    else
-    {
-      particlePtr->setjetBtagCSV(-1);
-    }
+    particle.setjetBtagCSV(btag);
   }
 }
 

--- a/Readers/interface/setJetBtagScore.h
+++ b/Readers/interface/setJetBtagScore.h
@@ -1,0 +1,34 @@
+#ifndef TallinnNtupleProducer_Readers_setJetBtagScore_h
+#define TallinnNtupleProducer_Readers_setJetBtagScore_h
+
+
+
+#include "TallinnNtupleProducer/Objects/interface/RecoJetAK4.h"
+#include "TallinnNtupleProducer/Objects/interface/RecoLepton.h"
+
+#include <assert.h>                                              // assert()
+#include <vector>                                                // std::vector
+
+template <typename T>
+void
+setJetBtagScore(std::vector<T> & particles, const std::vector<RecoJetAK4> & jets)
+{
+  Int_t njets = jets.size();
+
+  for ( T & particle : particles )
+  {
+    T * particlePtr = &particle;
+    Int_t jetIdx = particlePtr->jetIdx();
+    if ( jetIdx >=0 &&  jetIdx <njets)
+    {
+      double btag = jets.at(jetIdx).BtagCSV();
+      particlePtr->setjetBtagCSV(btag);
+    }
+    else
+    {
+      particlePtr->setjetBtagCSV(-1);
+    }
+  }
+}
+
+#endif // TallinnNtupleProducer_Readers_setJetBtagScore_h

--- a/Readers/src/RecoElectronReader.cc
+++ b/Readers/src/RecoElectronReader.cc
@@ -215,11 +215,6 @@ RecoElectronReader::read() const
 
         RecoElectron & electron = electrons.back();
 
-        for(const auto & kv: gLeptonReader->assocJetBtagCSVs_)
-        {
-          const double val = kv.second[idxLepton];
-          electron.assocJetBtagCSVs_[kv.first] = std::isnan(val) ? -2. : val;
-        }
         for(const auto & EGammaID_choice: gElectronReader->rawMVAs_POG_)
         {
           electron.egammaID_raws_[EGammaID_choice.first] = EGammaID_choice.second[idxLepton];

--- a/Readers/src/RecoLeptonReader.cc
+++ b/Readers/src/RecoLeptonReader.cc
@@ -101,11 +101,6 @@ RecoLeptonReader::~RecoLeptonReader()
     delete[] gInstance->genPartFlav_;
     delete[] gInstance->genMatchIdx_;
 
-    for(auto & kv: gInstance->assocJetBtagCSVs_)
-    {
-      delete[] kv.second;
-    }
-
     instances_[branchName_obj_] = nullptr;
   }
 }
@@ -130,21 +125,6 @@ RecoLeptonReader::setBranchNames()
     branchName_mvaRawTTH_ = Form("%s_%s", branchName_obj_.data(), "mvaTTH");
     branchName_jetRelIso_ = Form("%s_%s", branchName_obj_.data(), "jetRelIso");
     branchName_jetNDauChargedMVASel_ = Form("%s_%s", branchName_obj_.data(), "jetNDauChargedMVASel");
-    for(Btag btag: { Btag::kCSVv2, Btag::kDeepCSV, Btag::kDeepJet })
-    {
-      if(btag == Btag::kCSVv2 && era_ == Era::k2018)
-      {
-        continue;
-      }
-      std::string btag_str = "";
-      switch(btag)
-      {
-        case Btag::kCSVv2:   btag_str = "CSV"; break;
-        case Btag::kDeepCSV: btag_str = "DeepCSV"; break;
-        case Btag::kDeepJet: btag_str = "DeepJet"; break;
-      }
-      branchNames_assocJetBtagCSV_[btag] = Form("%s_assocJetBtag_%s", branchName_obj_.data(), btag_str.data());
-    }
     branchName_tightCharge_ = Form("%s_%s", branchName_obj_.data(), "tightCharge");
     branchName_charge_ = Form("%s_%s", branchName_obj_.data(), "charge");
     branchName_jetIdx_ = Form("%s_%s", branchName_obj_.data(), "jetIdx");
@@ -199,10 +179,6 @@ RecoLeptonReader::setBranchAddresses(TTree * tree)
     bai.setBranchAddress(sip3d_, branchName_sip3d_);
     bai.setBranchAddress(mvaRawTTH_, branchName_mvaRawTTH_);
     bai.setBranchAddress(jetRelIso_, branchName_jetRelIso_);
-    for(const auto & kv: branchNames_assocJetBtagCSV_)
-    {
-      bai.setBranchAddress(assocJetBtagCSVs_[kv.first], kv.second);
-    }
     bai.setBranchAddress(tightCharge_, branchName_tightCharge_);
     bai.setBranchAddress(charge_, branchName_charge_);
     bai.setBranchAddress(jetIdx_, branchName_jetIdx_);

--- a/Readers/src/RecoMuonReader.cc
+++ b/Readers/src/RecoMuonReader.cc
@@ -146,11 +146,6 @@ RecoMuonReader::read() const
             }));
         RecoMuon & muon = muons.back();
 
-        for(const auto & kv: gLeptonReader->assocJetBtagCSVs_)
-        {
-          const double val = kv.second[idxLepton];
-          muon.assocJetBtagCSVs_[kv.first] = std::isnan(val) ? -2. : val;
-        }
         if(mvaTTH_wp_ > 0.)
         {
           muon.set_mvaRawTTH_cut(mvaTTH_wp_);


### PR DESCRIPTION
Currently jetBtagScore of lepton is set in post-processing step [here](https://github.com/HEP-KBFI/tth-nanoAOD-tools/blob/master/python/postprocessing/modules/lepJetVarProducer.py) . But we can do this in the flat ntuple production. Since DeepJet is the only BtagScore, we use, currently only this score is set