### PR TITLE
Apply trigger SF, save weights for corresponding shifts in the SF

### DIFF
--- a/CommonTools/interface/sysUncertOptions.h
+++ b/CommonTools/interface/sysUncertOptions.h
@@ -155,7 +155,6 @@ enum class TriggerSFsys
 {
   central,
   shiftUp,          shiftDown,
-  shift_2lssUp,     shift_2lssDown,
   shift_2lssEEUp,   shift_2lssEEDown,
   shift_2lssEMuUp,  shift_2lssEMuDown,
   shift_2lssMuMuUp, shift_2lssMuMuDown,
@@ -287,7 +286,10 @@ extern const std::map<std::string, PDFSys> pdfSysMap;
 // experimental uncertainties
 extern const std::map<std::string, L1PreFiringWeightSys> l1prefireSysMap;
 extern const std::map<std::string, PUsys> puSysMap;
-extern const std::map<std::string, TriggerSFsys> triggerSFSysMap; // NOT WRITTEN YET
+extern const std::map<std::string, TriggerSFsys> triggerSFSysMap;
+extern const std::map<std::string, TriggerSFsys> triggerSFSysMap_2lss;
+extern const std::map<std::string, TriggerSFsys> triggerSFSysMap_1l_1tau;
+extern const std::map<std::string, TriggerSFsys> triggerSFSysMap_0l_2tau;
 
 // AK4 jet uncertainties
 extern const std::map<std::string, int> btagWeightSysMap;

--- a/CommonTools/src/sysUncertOptions.cc
+++ b/CommonTools/src/sysUncertOptions.cc
@@ -2,7 +2,6 @@
 
 #include "TallinnNtupleProducer/CommonTools/interface/cmsException.h"            // cmsException
 #include "TallinnNtupleProducer/CommonTools/interface/Era.h"                     // Era
-#include "TallinnNtupleProducer/CommonTools/interface/jetDefinitions.h"          // Btag
 #include "TallinnNtupleProducer/CommonTools/interface/merge_systematic_shifts.h" // merge_systematic_shifts()
 #include "TallinnNtupleProducer/CommonTools/interface/contains.h"                // contains()
 #include "TallinnNtupleProducer/CommonTools/interface/map_keys.h"                // map_keys()
@@ -233,16 +232,23 @@ const std::map<std::string, TauIDSFsys> tauIDSFSysMap = {
 const std::map<std::string, TriggerSFsys> triggerSFSysMap = {
   { "CMS_ttHl_triggerUp",            TriggerSFsys::shiftUp            },
   { "CMS_ttHl_triggerDown",          TriggerSFsys::shiftDown          },
-  { "CMS_ttHl_trigger_2lssUp",       TriggerSFsys::shift_2lssUp       },
-  { "CMS_ttHl_trigger_2lssDown",     TriggerSFsys::shift_2lssDown     },
+};
+
+const std::map<std::string, TriggerSFsys> triggerSFSysMap_2lss = {
   { "CMS_ttHl_trigger_2lssEEUp",     TriggerSFsys::shift_2lssEEUp     },
   { "CMS_ttHl_trigger_2lssEEDown",   TriggerSFsys::shift_2lssEEDown   },
   { "CMS_ttHl_trigger_2lssEMuUp",    TriggerSFsys::shift_2lssEMuUp    },
   { "CMS_ttHl_trigger_2lssEMuDown",  TriggerSFsys::shift_2lssEMuDown  },
   { "CMS_ttHl_trigger_2lssMuMuUp",   TriggerSFsys::shift_2lssMuMuUp   },
   { "CMS_ttHl_trigger_2lssMuMuDown", TriggerSFsys::shift_2lssMuMuDown },
+};
+
+const std::map<std::string, TriggerSFsys> triggerSFSysMap_1l_1tau = {
   { "CMS_ttHl_trigger_1l1tauUp",     TriggerSFsys::shift_1l1tauUp     },
   { "CMS_ttHl_trigger_1l1tauDown",   TriggerSFsys::shift_1l1tauDown   },
+};
+
+const std::map<std::string, TriggerSFsys> triggerSFSysMap_0l_2tau = {
   { "CMS_ttHl_trigger_0l2tauUp",     TriggerSFsys::shift_0l2tauUp     },
   { "CMS_ttHl_trigger_0l2tauDown",   TriggerSFsys::shift_0l2tauDown   },
 };
@@ -594,15 +600,18 @@ getTriggerSF_option(const std::string & central_or_shift,
   const bool isHadTauCompatible = choice == TriggerSFsysChoice::any || choice == TriggerSFsysChoice::hadTauOnly;
   const bool isAnyCompatible = isLeptonCompatible || isHadTauCompatible;
 
-  const auto kv = triggerSFSysMap.find(central_or_shift);
-  if(kv != triggerSFSysMap.end())
+  for(const auto & sysMap: { triggerSFSysMap, triggerSFSysMap_2lss, triggerSFSysMap_1l_1tau, triggerSFSysMap_0l_2tau })
   {
-    const TriggerSFsys central_or_shift_int = kv->second;
-    if(((central_or_shift_int == TriggerSFsys::shiftUp || central_or_shift_int == TriggerSFsys::shiftDown) && isAnyCompatible) ||
-       (central_or_shift.find("tau") == std::string::npos && isLeptonCompatible) ||
-       (central_or_shift.find("tau") != std::string::npos && isHadTauCompatible))
+    const auto kv = sysMap.find(central_or_shift);
+    if(kv != sysMap.end())
     {
-      return central_or_shift_int;
+      const TriggerSFsys central_or_shift_int = kv->second;
+      if(((central_or_shift_int == TriggerSFsys::shiftUp || central_or_shift_int == TriggerSFsys::shiftDown) && isAnyCompatible) ||
+         (central_or_shift.find("tau") == std::string::npos && isLeptonCompatible) ||
+         (central_or_shift.find("tau") != std::string::npos && isHadTauCompatible))
+      {
+        return central_or_shift_int;
+      }
     }
   }
   return TriggerSFsys::central;

--- a/EvtWeightTools/interface/Data_to_MC_CorrectionInterface_0l_2tau_trigger.h
+++ b/EvtWeightTools/interface/Data_to_MC_CorrectionInterface_0l_2tau_trigger.h
@@ -2,12 +2,6 @@
 #define TallinnNtupleProducer_EvtWeightTools_Data_to_MC_CorrectionInterface_0l_2tau_trigger_h
 
 #include "TallinnNtupleProducer/EvtWeightTools/interface/Data_to_MC_CorrectionInterface_trigger_Base.h" // Data_to_MC_CorrectionInterface_trigger_Base
-#include "TallinnNtupleProducer/EvtWeightTools/interface/lutAuxFunctions.h"                             // lutWrapperBase, vLutWrapperBase
-
-#include "correction.h"
-
-// forward declarations
-enum class TriggerSFsys;
 
 class Data_to_MC_CorrectionInterface_0l_2tau_trigger
   : public Data_to_MC_CorrectionInterface_trigger_Base
@@ -18,9 +12,6 @@ class Data_to_MC_CorrectionInterface_0l_2tau_trigger
 
   //-----------------------------------------------------------------------------
 
-  void
-  set_0l_2tau_trigger_sf(correction::Correction::Ref cset);
-
   // set HLT trigger bits
   // (to be called once per event, before calling any of the getSF.. functions)
 
@@ -30,8 +21,8 @@ class Data_to_MC_CorrectionInterface_0l_2tau_trigger
 
   //-----------------------------------------------------------------------------
   // data/MC correction for trigger efficiency 
-  double
-  getSF_triggerEff(TriggerSFsys central_or_shift) const;
+  virtual double
+  getSF_triggerEff(TriggerSFsys central_or_shift) const override;
   //-----------------------------------------------------------------------------
 
  protected:
@@ -39,12 +30,6 @@ class Data_to_MC_CorrectionInterface_0l_2tau_trigger
   check_triggerSFsys_opt(TriggerSFsys central_or_shift) const;
 
   bool isTriggered_2tau_;
-
-  //-----------------------------------------------------------------------------
-  // data/MC corrections for trigger efficiencies
-
-  correction::Correction::Ref sf_0l_2tau_trigger_;
-  //-----------------------------------------------------------------------------
 };
 
 #endif // TallinnNtupleProducer_EvtWeightTools_Data_to_MC_CorrectionInterface_0l_2tau_trigger_h

--- a/EvtWeightTools/interface/Data_to_MC_CorrectionInterface_0l_4tau_trigger.h
+++ b/EvtWeightTools/interface/Data_to_MC_CorrectionInterface_0l_4tau_trigger.h
@@ -12,8 +12,8 @@ public:
 
   //-----------------------------------------------------------------------------
   // data/MC correction for trigger efficiency 
-  double
-  getSF_triggerEff(TriggerSFsys central_or_shift) const;
+  virtual double
+  getSF_triggerEff(TriggerSFsys central_or_shift) const override;
   //-----------------------------------------------------------------------------
 
 protected:

--- a/EvtWeightTools/interface/Data_to_MC_CorrectionInterface_1l_1tau_trigger.h
+++ b/EvtWeightTools/interface/Data_to_MC_CorrectionInterface_1l_1tau_trigger.h
@@ -3,11 +3,6 @@
 
 #include "TallinnNtupleProducer/EvtWeightTools/interface/Data_to_MC_CorrectionInterface_trigger_Base.h" // Data_to_MC_CorrectionInterface_trigger_Base
 #include "TallinnNtupleProducer/EvtWeightTools/interface/lutAuxFunctions.h"                             // lutWrapperBase, vLutWrapperBase
-#include "correction.h"
-
-// forward declarations
-enum class TriggerSFsys;
-
 
 class Data_to_MC_CorrectionInterface_1l_1tau_trigger
   : public Data_to_MC_CorrectionInterface_trigger_Base
@@ -17,9 +12,6 @@ class Data_to_MC_CorrectionInterface_1l_1tau_trigger
   ~Data_to_MC_CorrectionInterface_1l_1tau_trigger();
 
   //-----------------------------------------------------------------------------
-
-  void
-  set_1l_1tau_trigger_sf(correction::Correction::Ref cset);
 
   // set HLT trigger bits
   // (to be called once per event, before calling any of the getSF.. functions)
@@ -32,8 +24,8 @@ class Data_to_MC_CorrectionInterface_1l_1tau_trigger
 
   //-----------------------------------------------------------------------------
   // data/MC correction for trigger efficiency 
-  double
-  getSF_triggerEff(TriggerSFsys central_or_shift) const;
+  virtual double
+  getSF_triggerEff(TriggerSFsys central_or_shift) const override;
   //-----------------------------------------------------------------------------
 
  protected:
@@ -59,8 +51,6 @@ class Data_to_MC_CorrectionInterface_1l_1tau_trigger
   vLutWrapperBase effTrigger_1m_mc_;
   vLutWrapperBase effTrigger_1m1tau_lepLeg_data_;
   vLutWrapperBase effTrigger_1m1tau_lepLeg_mc_;
-
-  correction::Correction::Ref sf_1l_1tau_trigger_;
   //-----------------------------------------------------------------------------
 };
 

--- a/EvtWeightTools/interface/Data_to_MC_CorrectionInterface_1l_2tau_trigger.h
+++ b/EvtWeightTools/interface/Data_to_MC_CorrectionInterface_1l_2tau_trigger.h
@@ -4,8 +4,6 @@
 #include "TallinnNtupleProducer/EvtWeightTools/interface/Data_to_MC_CorrectionInterface_trigger_Base.h" // Data_to_MC_CorrectionInterface_trigger_Base
 #include "TallinnNtupleProducer/EvtWeightTools/interface/lutAuxFunctions.h"                             // lutWrapperBase, vLutWrapperBase
 
-#include "correction.h"
-
 // forward declarations
 enum class TriggerSFsys;
 
@@ -18,9 +16,6 @@ class Data_to_MC_CorrectionInterface_1l_2tau_trigger
 
   //-----------------------------------------------------------------------------
 
-  void
-  set_1l_2tau_trigger_sf(correction::Correction::Ref cset);
-
   // set HLT trigger bits
   // (to be called once per event, before calling any of the getSF.. functions)
   void
@@ -32,8 +27,8 @@ class Data_to_MC_CorrectionInterface_1l_2tau_trigger
 
   //-----------------------------------------------------------------------------
   // data/MC correction for trigger efficiency 
-  double
-  getSF_triggerEff(TriggerSFsys central_or_shift) const;
+  virtual double
+  getSF_triggerEff(TriggerSFsys central_or_shift) const override;
   //-----------------------------------------------------------------------------
 
  protected:
@@ -59,9 +54,6 @@ class Data_to_MC_CorrectionInterface_1l_2tau_trigger
   vLutWrapperBase effTrigger_1m_mc_;
   vLutWrapperBase effTrigger_1m1tau_lepLeg_data_;
   vLutWrapperBase effTrigger_1m1tau_lepLeg_mc_;
-
-  correction::Correction::Ref sf_1l_2tau_trigger_;
-
   //-----------------------------------------------------------------------------
 };
 

--- a/EvtWeightTools/interface/Data_to_MC_CorrectionInterface_1l_3tau_trigger.h
+++ b/EvtWeightTools/interface/Data_to_MC_CorrectionInterface_1l_3tau_trigger.h
@@ -12,9 +12,6 @@ public:
 
   //-----------------------------------------------------------------------------
 
-  void
-  set_0l_2tau_trigger_sf(correction::Correction::Ref cset);
-
   // set HLT trigger bits
   // (to be called once per event, before calling any of the getSF.. functions)
   void
@@ -32,8 +29,8 @@ public:
 
   //-----------------------------------------------------------------------------
   // data/MC correction for trigger efficiency 
-  double
-  getSF_triggerEff(TriggerSFsys central_or_shift) const;
+  virtual double
+  getSF_triggerEff(TriggerSFsys central_or_shift) const override;
   //-----------------------------------------------------------------------------
 
 protected:
@@ -71,8 +68,6 @@ protected:
               double eff_2tau_tauLeg) const;
 
   bool isTriggered_2tau_;
-
-  correction::Correction::Ref sf_0l_2tau_trigger_;
 };
 
 #endif // TallinnNtupleProducer_EvtWeightTools_Data_to_MC_CorrectionInterface_1l_3tau_trigger_h

--- a/EvtWeightTools/interface/Data_to_MC_CorrectionInterface_trigger_Base.h
+++ b/EvtWeightTools/interface/Data_to_MC_CorrectionInterface_trigger_Base.h
@@ -1,8 +1,13 @@
 #ifndef TallinnNtupleProducer_EvtWeightTools_Data_to_MC_CorrectionInterface_trigger_Base_h
 #define TallinnNtupleProducer_EvtWeightTools_Data_to_MC_CorrectionInterface_trigger_Base_h
 
-#include "FWCore/ParameterSet/interface/ParameterSet.h"                  // edm::ParameterSet
-#include <iostream>                                                      // std::cout
+#include "TallinnNtupleProducer/EvtWeightTools/interface/TauTriggerSFValues.h" // TauTriggerSFValues
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"                        // edm::ParameterSet
+
+#include "correction.h"                                                        // correction::CorrectionSet, correction::Correction::Ref
+
+#include <iostream>                                                            // std::cout
 
 // forward declarations
 class RecoHadTau;
@@ -10,12 +15,13 @@ class RecoLepton;
 
 enum class Era;
 enum class TauID;
+enum class TriggerSFsys;
 
 class Data_to_MC_CorrectionInterface_trigger_Base
 {
  public:
   Data_to_MC_CorrectionInterface_trigger_Base(const edm::ParameterSet & cfg);
-  ~Data_to_MC_CorrectionInterface_trigger_Base();
+  virtual ~Data_to_MC_CorrectionInterface_trigger_Base() = default;
 
   //-----------------------------------------------------------------------------
 
@@ -23,17 +29,37 @@ class Data_to_MC_CorrectionInterface_trigger_Base
   // set hadTau pT, eta and decay mode
   // (to be called once per event, before calling any of the getSF.. functions)
   void
-  setHadTaus(const std::vector<const RecoHadTau * >& hadTaus);
+  setHadTaus(const std::vector<const RecoHadTau * > & hadTaus);
   //-----------------------------------------------------------------------------
 
   // set lepton type, pT and eta as well as hadTau pT, eta and decay mode
   // (to be called once per event, before calling any of the getSF.. functions)
   void
-    setLepton(const RecoLepton * const lepton);
+  setLeptons(const std::vector<const RecoLepton *> & leptons);
 
+  // data/MC correction for trigger efficiency
+  virtual double
+  getSF_triggerEff(TriggerSFsys central_or_shift) const = 0;
   //----------------------------------------------------------------------------- 
 
  protected:
+
+  static const std::map<std::string, double> tau_trigger_ptThresholds_;
+
+  double
+  tau_leg_efficiency(double pt,
+                     int dm,
+                     const std::string & trigger_type,
+                     const std::string & wp,
+                     const std::string & data_type,
+                     const std::string & sys) const;
+
+  TauTriggerSFValues
+  tau_leg_efficiency(double pt,
+                     int dm,
+                     const std::string & trigger_type,
+                     const std::string & wp,
+                     const std::string & data_type) const;
 
   std::string era_str_;
   Era era_;
@@ -71,6 +97,9 @@ class Data_to_MC_CorrectionInterface_trigger_Base
 
   const TauID tauId_;
   const std::string wp_str_;
+
+  std::unique_ptr<correction::CorrectionSet> tau_tigger_cset_;
+  correction::Correction::Ref sf_trigger_;
   //-----------------------------------------------------------------------------
   // data/MC corrections for trigger efficiencies
   //-----------------------------------------------------------------------------

--- a/EvtWeightTools/interface/EvtWeightRecorder.h
+++ b/EvtWeightTools/interface/EvtWeightRecorder.h
@@ -21,9 +21,7 @@ class RecoHadTau;
 class EvtWeightManager;
 class DYMCReweighting;
 class DYMCNormScaleFactors;
-class Data_to_MC_CorrectionInterface_0l_2tau_trigger;
-class Data_to_MC_CorrectionInterface_1l_1tau_trigger;
-class Data_to_MC_CorrectionInterface_1l_2tau_trigger;
+class Data_to_MC_CorrectionInterface_trigger_Base;
 class HHWeightInterfaceLO;
 class HHWeightInterfaceNLO;
 class LHEVpt_LOtoNLO;
@@ -279,13 +277,7 @@ class EvtWeightRecorder
   record_leptonTriggerEff(const Data_to_MC_CorrectionInterface_Base * const dataToMCcorrectionInterface);
 
   void
-  record_tauTriggerEff(const Data_to_MC_CorrectionInterface_0l_2tau_trigger * const dataToMCcorrectionInterface_0l_2tau_trigger);
-
-  void
-  record_tauTriggerEff(const Data_to_MC_CorrectionInterface_1l_1tau_trigger * const dataToMCcorrectionInterface_1l_1tau_trigger);
-
-  void
-  record_tauTriggerEff(const Data_to_MC_CorrectionInterface_1l_2tau_trigger * const dataToMCcorrectionInterface_1l_2tau_trigger);
+  record_tauTriggerEff(const Data_to_MC_CorrectionInterface_trigger_Base * const dataToMCcorrectionInterface_trigger);
 
   void
   record_hadTauID_and_Iso(const Data_to_MC_CorrectionInterface_Base * const dataToMCcorrectionInterface);

--- a/EvtWeightTools/interface/data_to_MC_corrections_auxFunctions.h
+++ b/EvtWeightTools/interface/data_to_MC_corrections_auxFunctions.h
@@ -17,6 +17,8 @@ enum class TriggerSFsys;
 
 namespace aux
 {
+  extern const std::map<std::string, double> tau_trigger_ptThresholds;
+
   std::string
   getEtaBinLabel(double etaMin,
                  double etaMax,
@@ -116,23 +118,6 @@ namespace aux
   loadTriggerEff_1m_1tau_lepLeg_2018(vLutWrapperBase & effTrigger_1m1tau_lepLeg_data,
                                      vLutWrapperBase & effTrigger_1m1tau_lepLeg_mc,
                                      std::map<std::string, TFile *> & inputFiles);
-
-  double
-  tau_leg_efficiency(const double pt, 
-                     const int dm, 
-                     const std::string trigger_type, 
-                     const std::string wp, 
-                     const std::string data_type, 
-                     const correction::Correction::Ref cset,
-                     const std::string & sys);
-
-  TauTriggerSFValues
-  tau_leg_efficiency(const double pt, 
-                     const int dm, 
-                     const std::string trigger_type, 
-                     const std::string wp, 
-                     const std::string data_type, 
-                     const correction::Correction::Ref cset);
 
   int
   get_btv_flavor(int hadronFlav);

--- a/EvtWeightTools/src/Data_to_MC_CorrectionInterface_0l_2tau_trigger.cc
+++ b/EvtWeightTools/src/Data_to_MC_CorrectionInterface_0l_2tau_trigger.cc
@@ -14,12 +14,6 @@ Data_to_MC_CorrectionInterface_0l_2tau_trigger::~Data_to_MC_CorrectionInterface_
 {}
 
 void
-Data_to_MC_CorrectionInterface_0l_2tau_trigger::set_0l_2tau_trigger_sf(correction::Correction::Ref cset)
-{
-  sf_0l_2tau_trigger_ = cset;
-}
-
-void
 Data_to_MC_CorrectionInterface_0l_2tau_trigger::setTriggerBits(bool isTriggered_2tau)
 {
   isTriggered_2tau_ = isTriggered_2tau;
@@ -55,14 +49,14 @@ Data_to_MC_CorrectionInterface_0l_2tau_trigger::getSF_triggerEff(TriggerSFsys ce
 
   if(std::fabs(hadTau1_eta_) <= 2.1 && aux::hasDecayMode(allowedDecayModes_, hadTau1_decayMode_))
   {
-    eff_2tau_tauLeg1_data = sf_0l_2tau_trigger_->evaluate({hadTau1_pt_, hadTau1_decayMode_, "diTau", wp_str_, "eff_data", sys});
-    eff_2tau_tauLeg1_mc   = sf_0l_2tau_trigger_->evaluate({hadTau1_pt_, hadTau1_decayMode_, "diTau", wp_str_, "eff_mc", sys});
+    eff_2tau_tauLeg1_data = tau_leg_efficiency(hadTau1_pt_, hadTau1_decayMode_, "ditau", wp_str_, "eff_data", sys);
+    eff_2tau_tauLeg1_mc   = tau_leg_efficiency(hadTau1_pt_, hadTau1_decayMode_, "ditau", wp_str_, "eff_mc", sys);
   }
 
   if(std::fabs(hadTau2_eta_) <= 2.1 && aux::hasDecayMode(allowedDecayModes_, hadTau2_decayMode_))
   {
-    eff_2tau_tauLeg2_data = sf_0l_2tau_trigger_->evaluate({hadTau2_pt_, hadTau2_decayMode_, "diTau", wp_str_, "eff_data", sys});
-    eff_2tau_tauLeg2_mc   = sf_0l_2tau_trigger_->evaluate({hadTau2_pt_, hadTau2_decayMode_, "diTau", wp_str_, "eff_mc", sys});
+    eff_2tau_tauLeg2_data = tau_leg_efficiency(hadTau2_pt_, hadTau2_decayMode_, "ditau", wp_str_, "eff_data", sys);
+    eff_2tau_tauLeg2_mc   = tau_leg_efficiency(hadTau2_pt_, hadTau2_decayMode_, "ditau", wp_str_, "eff_mc", sys);
   }
 
   if(isDEBUG_)

--- a/EvtWeightTools/src/Data_to_MC_CorrectionInterface_0l_4tau_trigger.cc
+++ b/EvtWeightTools/src/Data_to_MC_CorrectionInterface_0l_4tau_trigger.cc
@@ -52,26 +52,26 @@ Data_to_MC_CorrectionInterface_0l_4tau_trigger::getSF_triggerEff(TriggerSFsys ce
 
   if(std::fabs(hadTau1_eta_) <= 2.1 && aux::hasDecayMode(allowedDecayModes_, hadTau1_decayMode_))
   {
-    eff_2tau_tauLeg1_data = sf_0l_2tau_trigger_->evaluate({hadTau1_pt_, hadTau1_decayMode_, "diTau", wp_str_, "eff_data", sys});
-    eff_2tau_tauLeg1_mc   = sf_0l_2tau_trigger_->evaluate({hadTau1_pt_, hadTau1_decayMode_, "diTau", wp_str_, "eff_mc", sys});
+    eff_2tau_tauLeg1_data = tau_leg_efficiency(hadTau1_pt_, hadTau1_decayMode_, "ditau", wp_str_, "eff_data", sys);
+    eff_2tau_tauLeg1_mc   = tau_leg_efficiency(hadTau1_pt_, hadTau1_decayMode_, "ditau", wp_str_, "eff_mc", sys);
   }
 
   if(std::fabs(hadTau2_eta_) <= 2.1 && aux::hasDecayMode(allowedDecayModes_, hadTau2_decayMode_))
   {
-    eff_2tau_tauLeg2_data = sf_0l_2tau_trigger_->evaluate({hadTau2_pt_, hadTau2_decayMode_, "diTau", wp_str_, "eff_data", sys});
-    eff_2tau_tauLeg2_mc   = sf_0l_2tau_trigger_->evaluate({hadTau2_pt_, hadTau2_decayMode_, "diTau", wp_str_, "eff_mc", sys});
+    eff_2tau_tauLeg2_data = tau_leg_efficiency(hadTau2_pt_, hadTau2_decayMode_, "ditau", wp_str_, "eff_data", sys);
+    eff_2tau_tauLeg2_mc   = tau_leg_efficiency(hadTau2_pt_, hadTau2_decayMode_, "ditau", wp_str_, "eff_mc", sys);
   }
 
   if(std::fabs(hadTau3_eta_) <= 2.1 && aux::hasDecayMode(allowedDecayModes_, hadTau3_decayMode_))
   {
-    eff_2tau_tauLeg3_data = sf_0l_2tau_trigger_->evaluate({hadTau3_pt_, hadTau2_decayMode_, "diTau", wp_str_, "eff_data", sys});
-    eff_2tau_tauLeg3_mc   = sf_0l_2tau_trigger_->evaluate({hadTau3_pt_, hadTau3_decayMode_, "diTau", wp_str_, "eff_mc", sys});
+    eff_2tau_tauLeg3_data = tau_leg_efficiency(hadTau3_pt_, hadTau2_decayMode_, "ditau", wp_str_, "eff_data", sys);
+    eff_2tau_tauLeg3_mc   = tau_leg_efficiency(hadTau3_pt_, hadTau3_decayMode_, "ditau", wp_str_, "eff_mc", sys);
   }
 
   if(std::fabs(hadTau4_eta_) <= 2.1 && aux::hasDecayMode(allowedDecayModes_, hadTau4_decayMode_))
   {
-    eff_2tau_tauLeg4_data = sf_0l_2tau_trigger_->evaluate({hadTau4_pt_, hadTau4_decayMode_, "diTau", wp_str_, "eff_data", sys});
-    eff_2tau_tauLeg4_mc   = sf_0l_2tau_trigger_->evaluate({hadTau4_pt_, hadTau4_decayMode_, "diTau", wp_str_, "eff_mc", sys});
+    eff_2tau_tauLeg4_data = tau_leg_efficiency(hadTau4_pt_, hadTau4_decayMode_, "ditau", wp_str_, "eff_data", sys);
+    eff_2tau_tauLeg4_mc   = tau_leg_efficiency(hadTau4_pt_, hadTau4_decayMode_, "ditau", wp_str_, "eff_mc", sys);
   }
 
   double prob_data = 0.;

--- a/EvtWeightTools/src/Data_to_MC_CorrectionInterface_1l_1tau_trigger.cc
+++ b/EvtWeightTools/src/Data_to_MC_CorrectionInterface_1l_1tau_trigger.cc
@@ -58,12 +58,6 @@ Data_to_MC_CorrectionInterface_1l_1tau_trigger::~Data_to_MC_CorrectionInterface_
 }
 
 void
-Data_to_MC_CorrectionInterface_1l_1tau_trigger::set_1l_1tau_trigger_sf(correction::Correction::Ref cset)
-{ 
-  sf_1l_1tau_trigger_ = cset;
-}
-
-void
 Data_to_MC_CorrectionInterface_1l_1tau_trigger::setTriggerBits(bool isTriggered_1e,
                                                                bool isTriggered_1e1tau,
                                                                bool isTriggered_1m,
@@ -107,8 +101,8 @@ Data_to_MC_CorrectionInterface_1l_1tau_trigger::getSF_triggerEff(TriggerSFsys ce
 
     if(std::fabs(hadTau1_eta_) <= 2.1 && aux::hasDecayMode(allowedDecayModes_, hadTau1_decayMode_))
     {
-      eff_1l1tau_tauLeg_data = aux::tau_leg_efficiency(hadTau1_pt_, hadTau1_decayMode_, "etau", wp_str_, "eff_data", sf_1l_1tau_trigger_);
-      eff_1l1tau_tauLeg_mc   = aux::tau_leg_efficiency(hadTau1_pt_, hadTau1_decayMode_, "etau", wp_str_, "eff_mc", sf_1l_1tau_trigger_);
+      eff_1l1tau_tauLeg_data = tau_leg_efficiency(hadTau1_pt_, hadTau1_decayMode_, "etau", wp_str_, "eff_data");
+      eff_1l1tau_tauLeg_mc   = tau_leg_efficiency(hadTau1_pt_, hadTau1_decayMode_, "etau", wp_str_, "eff_mc");
     }
 
     isTriggered_1l     = isTriggered_1e_;
@@ -127,8 +121,8 @@ Data_to_MC_CorrectionInterface_1l_1tau_trigger::getSF_triggerEff(TriggerSFsys ce
 
     if(std::fabs(hadTau1_eta_) <= 2.1 && aux::hasDecayMode(allowedDecayModes_, hadTau1_decayMode_))
     {
-      eff_1l1tau_tauLeg_data = aux::tau_leg_efficiency(hadTau1_pt_, hadTau1_decayMode_, "mutau", wp_str_, "eff_data", sf_1l_1tau_trigger_);
-      eff_1l1tau_tauLeg_mc   = aux::tau_leg_efficiency(hadTau1_pt_, hadTau1_decayMode_, "mutau", wp_str_, "eff_mc", sf_1l_1tau_trigger_);
+      eff_1l1tau_tauLeg_data = tau_leg_efficiency(hadTau1_pt_, hadTau1_decayMode_, "mutau", wp_str_, "eff_data");
+      eff_1l1tau_tauLeg_mc   = tau_leg_efficiency(hadTau1_pt_, hadTau1_decayMode_, "mutau", wp_str_, "eff_mc");
     }
 
     isTriggered_1l     = isTriggered_1m_;

--- a/EvtWeightTools/src/Data_to_MC_CorrectionInterface_1l_2tau_trigger.cc
+++ b/EvtWeightTools/src/Data_to_MC_CorrectionInterface_1l_2tau_trigger.cc
@@ -58,12 +58,6 @@ Data_to_MC_CorrectionInterface_1l_2tau_trigger::~Data_to_MC_CorrectionInterface_
 }
 
 void
-Data_to_MC_CorrectionInterface_1l_2tau_trigger::set_1l_2tau_trigger_sf(correction::Correction::Ref cset)
-{
-  sf_1l_2tau_trigger_ = cset;
-}
-
-void
 Data_to_MC_CorrectionInterface_1l_2tau_trigger::setTriggerBits(bool isTriggered_1e,
                                                                bool isTriggered_1e1tau,
                                                                bool isTriggered_1m,
@@ -109,14 +103,14 @@ Data_to_MC_CorrectionInterface_1l_2tau_trigger::getSF_triggerEff(TriggerSFsys ce
 
     if(std::fabs(hadTau1_eta_) <= 2.1 && aux::hasDecayMode(allowedDecayModes_, hadTau1_decayMode_))
     {
-      eff_1l1tau_tauLeg1_data = aux::tau_leg_efficiency(hadTau1_pt_, hadTau1_decayMode_, "etau", wp_str_, "eff_data", sf_1l_2tau_trigger_);
-      eff_1l1tau_tauLeg1_mc = aux::tau_leg_efficiency(hadTau1_pt_, hadTau1_decayMode_, "etau", wp_str_, "eff_mc", sf_1l_2tau_trigger_);
+      eff_1l1tau_tauLeg1_data = tau_leg_efficiency(hadTau1_pt_, hadTau1_decayMode_, "etau", wp_str_, "eff_data");
+      eff_1l1tau_tauLeg1_mc = tau_leg_efficiency(hadTau1_pt_, hadTau1_decayMode_, "etau", wp_str_, "eff_mc");
     }
 
     if(std::fabs(hadTau2_eta_) <= 2.1 && aux::hasDecayMode(allowedDecayModes_, hadTau2_decayMode_))
     {
-      eff_1l1tau_tauLeg2_data = aux::tau_leg_efficiency(hadTau2_pt_, hadTau2_decayMode_, "etau", wp_str_, "eff_data", sf_1l_2tau_trigger_);
-      eff_1l1tau_tauLeg2_mc   = aux::tau_leg_efficiency(hadTau2_pt_, hadTau2_decayMode_, "etau", wp_str_, "eff_mc", sf_1l_2tau_trigger_);
+      eff_1l1tau_tauLeg2_data = tau_leg_efficiency(hadTau2_pt_, hadTau2_decayMode_, "etau", wp_str_, "eff_data");
+      eff_1l1tau_tauLeg2_mc   = tau_leg_efficiency(hadTau2_pt_, hadTau2_decayMode_, "etau", wp_str_, "eff_mc");
     }
 
     isTriggered_1l     = isTriggered_1e_;
@@ -135,14 +129,14 @@ Data_to_MC_CorrectionInterface_1l_2tau_trigger::getSF_triggerEff(TriggerSFsys ce
 
     if(std::fabs(hadTau1_eta_) <= 2.1 && aux::hasDecayMode(allowedDecayModes_, hadTau1_decayMode_))
     {
-      eff_1l1tau_tauLeg1_data = aux::tau_leg_efficiency(hadTau1_pt_, hadTau1_decayMode_, "mtau", wp_str_, "eff_data", sf_1l_2tau_trigger_);
-      eff_1l1tau_tauLeg1_mc = aux::tau_leg_efficiency(hadTau1_pt_,hadTau1_decayMode_, "mtau", wp_str_, "eff_mc", sf_1l_2tau_trigger_);
+      eff_1l1tau_tauLeg1_data = tau_leg_efficiency(hadTau1_pt_, hadTau1_decayMode_, "mtau", wp_str_, "eff_data");
+      eff_1l1tau_tauLeg1_mc = tau_leg_efficiency(hadTau1_pt_,hadTau1_decayMode_, "mtau", wp_str_, "eff_mc");
     }
 
     if(std::fabs(hadTau2_eta_) <= 2.1 && aux::hasDecayMode(allowedDecayModes_, hadTau2_decayMode_))
     {
-      eff_1l1tau_tauLeg2_data = aux::tau_leg_efficiency(hadTau2_pt_, hadTau2_decayMode_, "mutau", wp_str_, "eff_data", sf_1l_2tau_trigger_);
-      eff_1l1tau_tauLeg2_mc   = aux::tau_leg_efficiency(hadTau2_pt_, hadTau2_decayMode_, "mutau", wp_str_, "eff_mc", sf_1l_2tau_trigger_);
+      eff_1l1tau_tauLeg2_data = tau_leg_efficiency(hadTau2_pt_, hadTau2_decayMode_, "mutau", wp_str_, "eff_data");
+      eff_1l1tau_tauLeg2_mc   = tau_leg_efficiency(hadTau2_pt_, hadTau2_decayMode_, "mutau", wp_str_, "eff_mc");
     }
 
     isTriggered_1l     = isTriggered_1m_;

--- a/EvtWeightTools/src/Data_to_MC_CorrectionInterface_1l_3tau_trigger.cc
+++ b/EvtWeightTools/src/Data_to_MC_CorrectionInterface_1l_3tau_trigger.cc
@@ -19,12 +19,6 @@ Data_to_MC_CorrectionInterface_1l_3tau_trigger::~Data_to_MC_CorrectionInterface_
 {}
 
 void
-Data_to_MC_CorrectionInterface_1l_3tau_trigger::set_0l_2tau_trigger_sf(correction::Correction::Ref cset)
-{
-  sf_0l_2tau_trigger_ = cset;
-}
-
-void
 Data_to_MC_CorrectionInterface_1l_3tau_trigger::setTriggerBits(bool isTriggered_1e,
                                                                bool isTriggered_1e1tau,
                                                                bool isTriggered_1m,
@@ -87,20 +81,20 @@ Data_to_MC_CorrectionInterface_1l_3tau_trigger::getSF_triggerEff(TriggerSFsys ce
 
     if(std::fabs(hadTau1_eta_) <= 2.1 && aux::hasDecayMode(allowedDecayModes_, hadTau1_decayMode_))
     {
-      eff_1l1tau_tauLeg1_data = aux::tau_leg_efficiency(hadTau1_pt_, hadTau1_decayMode_, "etau", wp_str_, "eff_data", sf_1l_2tau_trigger_, sys);
-      eff_1l1tau_tauLeg1_mc = aux::tau_leg_efficiency(hadTau1_pt_, hadTau1_decayMode_, "etau", wp_str_, "eff_mc", sf_1l_2tau_trigger_, sys);
+      eff_1l1tau_tauLeg1_data = tau_leg_efficiency(hadTau1_pt_, hadTau1_decayMode_, "etau", wp_str_, "eff_data", sys);
+      eff_1l1tau_tauLeg1_mc = tau_leg_efficiency(hadTau1_pt_, hadTau1_decayMode_, "etau", wp_str_, "eff_mc", sys);
     }
 
     if(std::fabs(hadTau2_eta_) <= 2.1 && aux::hasDecayMode(allowedDecayModes_, hadTau2_decayMode_))
     {
-      eff_1l1tau_tauLeg2_data = aux::tau_leg_efficiency(hadTau2_pt_, hadTau2_decayMode_, "etau", wp_str_, "eff_data", sf_1l_2tau_trigger_, sys);
-      eff_1l1tau_tauLeg2_mc = aux::tau_leg_efficiency(hadTau2_pt_, hadTau2_decayMode_, "etau", wp_str_, "eff_mc", sf_1l_2tau_trigger_, sys);
+      eff_1l1tau_tauLeg2_data = tau_leg_efficiency(hadTau2_pt_, hadTau2_decayMode_, "etau", wp_str_, "eff_data", sys);
+      eff_1l1tau_tauLeg2_mc = tau_leg_efficiency(hadTau2_pt_, hadTau2_decayMode_, "etau", wp_str_, "eff_mc", sys);
     }
 
     if(std::fabs(hadTau3_eta_) <= 2.1 && aux::hasDecayMode(allowedDecayModes_, hadTau3_decayMode_))
     {
-      eff_1l1tau_tauLeg3_data = aux::tau_leg_efficiency(hadTau3_pt_, hadTau3_decayMode_, "etau", wp_str_, "eff_data", sf_1l_2tau_trigger_, sys);
-      eff_1l1tau_tauLeg3_mc = aux::tau_leg_efficiency(hadTau3_pt_, hadTau3_decayMode_, "etau", wp_str_, "eff_mc", sf_1l_2tau_trigger_, sys);
+      eff_1l1tau_tauLeg3_data = tau_leg_efficiency(hadTau3_pt_, hadTau3_decayMode_, "etau", wp_str_, "eff_data", sys);
+      eff_1l1tau_tauLeg3_mc = tau_leg_efficiency(hadTau3_pt_, hadTau3_decayMode_, "etau", wp_str_, "eff_mc", sys);
     }
 
     isTriggered_1l     = isTriggered_1e_;
@@ -119,20 +113,20 @@ Data_to_MC_CorrectionInterface_1l_3tau_trigger::getSF_triggerEff(TriggerSFsys ce
 
     if(std::fabs(hadTau1_eta_) <= 2.1 && aux::hasDecayMode(allowedDecayModes_, hadTau1_decayMode_))
     {
-      eff_1l1tau_tauLeg1_data = aux::tau_leg_efficiency(hadTau1_pt_, hadTau1_decayMode_, "mtau", wp_str_, "eff_data", sf_1l_2tau_trigger_, sys);
-      eff_1l1tau_tauLeg1_mc = aux::tau_leg_efficiency(hadTau1_pt_, hadTau1_decayMode_, "mtau", wp_str_, "eff_mc", sf_1l_2tau_trigger_, sys);
+      eff_1l1tau_tauLeg1_data = tau_leg_efficiency(hadTau1_pt_, hadTau1_decayMode_, "mtau", wp_str_, "eff_data", sys);
+      eff_1l1tau_tauLeg1_mc = tau_leg_efficiency(hadTau1_pt_, hadTau1_decayMode_, "mtau", wp_str_, "eff_mc", sys);
     }
 
     if(std::fabs(hadTau2_eta_) <= 2.1 && aux::hasDecayMode(allowedDecayModes_, hadTau2_decayMode_))
     {
-      eff_1l1tau_tauLeg2_data = aux::tau_leg_efficiency(hadTau2_pt_, hadTau2_decayMode_, "mtau", wp_str_, "eff_data", sf_1l_2tau_trigger_, sys);
-      eff_1l1tau_tauLeg2_mc = aux::tau_leg_efficiency(hadTau2_pt_, hadTau2_decayMode_, "mtau", wp_str_, "eff_mc", sf_1l_2tau_trigger_, sys);
+      eff_1l1tau_tauLeg2_data = tau_leg_efficiency(hadTau2_pt_, hadTau2_decayMode_, "mtau", wp_str_, "eff_data", sys);
+      eff_1l1tau_tauLeg2_mc = tau_leg_efficiency(hadTau2_pt_, hadTau2_decayMode_, "mtau", wp_str_, "eff_mc", sys);
     }
 
     if(std::fabs(hadTau3_eta_) <= 2.1 && aux::hasDecayMode(allowedDecayModes_, hadTau3_decayMode_))
     {
-      eff_1l1tau_tauLeg3_data = aux::tau_leg_efficiency(hadTau3_pt_, hadTau3_decayMode_, "mtau", wp_str_, "eff_data", sf_1l_2tau_trigger_, sys);
-      eff_1l1tau_tauLeg3_mc = aux::tau_leg_efficiency(hadTau3_pt_, hadTau3_decayMode_, "mtau", wp_str_, "eff_mc", sf_1l_2tau_trigger_, sys);
+      eff_1l1tau_tauLeg3_data = tau_leg_efficiency(hadTau3_pt_, hadTau3_decayMode_, "mtau", wp_str_, "eff_data", sys);
+      eff_1l1tau_tauLeg3_mc = tau_leg_efficiency(hadTau3_pt_, hadTau3_decayMode_, "mtau", wp_str_, "eff_mc", sys);
     }
 
     isTriggered_1l     = isTriggered_1m_;
@@ -161,14 +155,14 @@ Data_to_MC_CorrectionInterface_1l_3tau_trigger::getSF_triggerEff(TriggerSFsys ce
     std::cout << "eff_1l1tau_tauLeg3_mc = " << eff_1l1tau_tauLeg3_mc << '\n';
   }
 
-  const double eff_2tau_tauLeg1_data = sf_0l_2tau_trigger_->evaluate({hadTau1_pt_, hadTau1_decayMode_, "diTau", wp_str_, "eff_data", sys});
-  const double eff_2tau_tauLeg1_mc   = sf_0l_2tau_trigger_->evaluate({hadTau1_pt_, hadTau1_decayMode_, "diTau", wp_str_, "eff_mc", sys});
+  const double eff_2tau_tauLeg1_data = tau_leg_efficiency(hadTau1_pt_, hadTau1_decayMode_, "ditau", wp_str_, "eff_data", sys);
+  const double eff_2tau_tauLeg1_mc   = tau_leg_efficiency(hadTau1_pt_, hadTau1_decayMode_, "ditau", wp_str_, "eff_mc", sys);
 
-  const double eff_2tau_tauLeg2_data = sf_0l_2tau_trigger_->evaluate({hadTau2_pt_, hadTau2_decayMode_, "diTau", wp_str_, "eff_data", sys});
-  const double eff_2tau_tauLeg2_mc   = sf_0l_2tau_trigger_->evaluate({hadTau2_pt_, hadTau2_decayMode_, "diTau", wp_str_, "eff_mc", sys});
+  const double eff_2tau_tauLeg2_data = tau_leg_efficiency(hadTau2_pt_, hadTau2_decayMode_, "ditau", wp_str_, "eff_data", sys);
+  const double eff_2tau_tauLeg2_mc   = tau_leg_efficiency(hadTau2_pt_, hadTau2_decayMode_, "ditau", wp_str_, "eff_mc", sys);
 
-  const double eff_2tau_tauLeg3_data = sf_0l_2tau_trigger_->evaluate({hadTau3_pt_, hadTau2_decayMode_, "diTau", wp_str_, "eff_data", sys});
-  const double eff_2tau_tauLeg3_mc   = sf_0l_2tau_trigger_->evaluate({hadTau3_pt_, hadTau3_decayMode_, "diTau", wp_str_, "eff_mc", sys});
+  const double eff_2tau_tauLeg3_data = tau_leg_efficiency(hadTau3_pt_, hadTau2_decayMode_, "ditau", wp_str_, "eff_data", sys);
+  const double eff_2tau_tauLeg3_mc   = tau_leg_efficiency(hadTau3_pt_, hadTau3_decayMode_, "ditau", wp_str_, "eff_mc", sys);
 
   if(isDEBUG_)
   {

--- a/EvtWeightTools/src/Data_to_MC_CorrectionInterface_Base.cc
+++ b/EvtWeightTools/src/Data_to_MC_CorrectionInterface_Base.cc
@@ -402,16 +402,14 @@ Data_to_MC_CorrectionInterface_Base::check_triggerSFsys_opt(TriggerSFsys central
   {
     return true;
   }
-  if(central_or_shift == TriggerSFsys::shift_2lssUp      ||
-     central_or_shift == TriggerSFsys::shift_2lssDown    ||
-     central_or_shift == TriggerSFsys::shift_2lssEEUp    ||
+  if(central_or_shift == TriggerSFsys::shift_2lssEEUp    ||
      central_or_shift == TriggerSFsys::shift_2lssEEDown  ||
      central_or_shift == TriggerSFsys::shift_2lssEMuUp   ||
      central_or_shift == TriggerSFsys::shift_2lssEMuDown ||
      central_or_shift == TriggerSFsys::shift_2lssMuMuUp  ||
      central_or_shift == TriggerSFsys::shift_2lssMuMuDown)
   {
-    return numLeptons_ <= 2 && numHadTaus_ <= 2;
+    return numLeptons_ == 2 && numHadTaus_ <= 2;
   }
   return false;
 }
@@ -429,7 +427,6 @@ Data_to_MC_CorrectionInterface_Base::comp_triggerSFsys_opt(double sf,
     return sf;
   }
   else if(central_or_shift == TriggerSFsys::shiftUp          ||
-          central_or_shift == TriggerSFsys::shift_2lssUp     ||
           central_or_shift == TriggerSFsys::shift_2lssEEUp   ||
           central_or_shift == TriggerSFsys::shift_2lssEMuUp  ||
           central_or_shift == TriggerSFsys::shift_2lssMuMuUp)
@@ -437,7 +434,6 @@ Data_to_MC_CorrectionInterface_Base::comp_triggerSFsys_opt(double sf,
     return sf * (1. + sfErr);
   }
   else if(central_or_shift == TriggerSFsys::shiftDown          ||
-          central_or_shift == TriggerSFsys::shift_2lssDown     ||
           central_or_shift == TriggerSFsys::shift_2lssEEDown   ||
           central_or_shift == TriggerSFsys::shift_2lssEMuDown  ||
           central_or_shift == TriggerSFsys::shift_2lssMuMuDown)

--- a/EvtWeightTools/src/Data_to_MC_CorrectionInterface_trigger_Base.cc
+++ b/EvtWeightTools/src/Data_to_MC_CorrectionInterface_trigger_Base.cc
@@ -1,17 +1,28 @@
 #include "TallinnNtupleProducer/EvtWeightTools/interface/Data_to_MC_CorrectionInterface_trigger_Base.h"
 
+#include "TallinnNtupleProducer/CommonTools/interface/LocalFileInPath.h"                        // LocalFileInPath
 #include "TallinnNtupleProducer/CommonTools/interface/leptonTypes.h"                            // getLeptonType()
-#include "TallinnNtupleProducer/CommonTools/interface/cmsException.h"                           // get_human_line()
 #include "TallinnNtupleProducer/CommonTools/interface/Era.h"                                    // Era, get_era()
 #include "TallinnNtupleProducer/Objects/interface/RecoHadTau.h"                                 // RecoHadTau
 #include "TallinnNtupleProducer/Objects/interface/RecoLepton.h"                                 // RecoLepton
 #include "TallinnNtupleProducer/CommonTools/interface/hadTauDefinitions.h"                      // get_tau_id_enum(), get_tau_id_wp_str()
+
+#include "TString.h"                                                                            // Form()
+
 #include <assert.h>                                                                             // assert()
+
+// TODO ask Tau POG to allow underflow
+const std::map<std::string, double> Data_to_MC_CorrectionInterface_trigger_Base::tau_trigger_ptThresholds_ = {
+  { "ditau",    40. },
+  { "etau",     25. },
+  { "mutau",    25. },
+  { "ditauvbf", 20. },
+};
 
 Data_to_MC_CorrectionInterface_trigger_Base::Data_to_MC_CorrectionInterface_trigger_Base(const edm::ParameterSet & cfg)
   : era_str_(cfg.getParameter<std::string>("era"))
   , era_(get_era(era_str_))
-  , hadTauSelection_(cfg.getParameter<std::string>("hadTauSelection"))
+  , hadTauSelection_(cfg.getParameter<std::string>("hadTauSelection_againstJets"))
   , isDEBUG_(cfg.exists("isDEBUG") ? cfg.getParameter<bool>("isDEBUG") : false)
   , allowedDecayModes_({ 0, 1, 2, 10, 11 })
   , lepton_type_(-1)
@@ -39,27 +50,35 @@ Data_to_MC_CorrectionInterface_trigger_Base::Data_to_MC_CorrectionInterface_trig
   , hadTau4_decayMode_(0)
   , tauId_(get_tau_id_enum(hadTauSelection_))
   , wp_str_(get_tau_id_wp_str(tauId_, get_tau_id_wp_int(hadTauSelection_)))
-{}
-
-Data_to_MC_CorrectionInterface_trigger_Base::~Data_to_MC_CorrectionInterface_trigger_Base()
-{}
+  , tau_tigger_cset_(nullptr)
+  , sf_trigger_(nullptr)
+{
+  const std::string tauTriggerCorrectionSetFile = LocalFileInPath(Form("TallinnNtupleProducer/EvtWeightTools/data/correctionlib/tau/%s/tau.json.gz", era_str_.data())).fullPath();
+  tau_tigger_cset_ = correction::CorrectionSet::from_file(tauTriggerCorrectionSetFile);
+  sf_trigger_ = tau_tigger_cset_->at("tau_trigger");
+}
 
 void
-Data_to_MC_CorrectionInterface_trigger_Base::setLepton(const RecoLepton * const lepton)
+Data_to_MC_CorrectionInterface_trigger_Base::setLeptons(const std::vector<const RecoLepton *> & leptons)
 {
-  lepton_type_ = getLeptonType(lepton->pdgId());
-  lepton_pt_   = lepton->pt();
-  lepton_eta_  = lepton->eta();
+  if(! leptons.empty())
+  {
+    lepton_type_ = getLeptonType(leptons[0]->pdgId());
+    lepton_pt_   = leptons[0]->pt();
+    lepton_eta_  = leptons[0]->eta();
+  }
 }
 
 void
 Data_to_MC_CorrectionInterface_trigger_Base::setHadTaus(const std::vector<const RecoHadTau *>& hadTaus)
 {
-  assert( !hadTaus.empty() );
-  hadTau1_pt_ = hadTaus[0]->pt();
-  hadTau1_eta_ = hadTaus[0]->eta();
-  hadTau1_phi_ = hadTaus[0]->phi();
-  hadTau1_decayMode_ = hadTaus[0]->decayMode();
+  if(! hadTaus.empty())
+  {
+    hadTau1_pt_ = hadTaus[0]->pt();
+    hadTau1_eta_ = hadTaus[0]->eta();
+    hadTau1_phi_ = hadTaus[0]->phi();
+    hadTau1_decayMode_ = hadTaus[0]->decayMode();
+  }
 
   if ( hadTaus.size() >1 )
   {
@@ -84,4 +103,28 @@ Data_to_MC_CorrectionInterface_trigger_Base::setHadTaus(const std::vector<const 
     hadTau4_phi_ = hadTaus[3]->phi();
     hadTau4_decayMode_ = hadTaus[3]->decayMode();
   }
+}
+
+double
+Data_to_MC_CorrectionInterface_trigger_Base::tau_leg_efficiency(double pt,
+                                                               int dm,
+                                                               const std::string & trigger_type,
+                                                               const std::string & wp,
+                                                               const std::string & data_type,
+                                                               const std::string & sys) const
+{
+  return sf_trigger_->evaluate({ std::max(pt, tau_trigger_ptThresholds_.at(trigger_type)), dm, trigger_type, wp, data_type, sys });
+}
+
+TauTriggerSFValues
+Data_to_MC_CorrectionInterface_trigger_Base::tau_leg_efficiency(double pt,
+                                                                int dm,
+                                                                const std::string & trigger_type,
+                                                                const std::string & wp,
+                                                                const std::string & data_type) const
+{
+  const double nom = tau_leg_efficiency(pt, dm, trigger_type, wp, data_type, "nom");
+  const double up = tau_leg_efficiency(pt, dm, trigger_type, wp, data_type, "up");
+  const double down = tau_leg_efficiency(pt, dm, trigger_type, wp, data_type, "down");
+  return { down, nom, up };
 }

--- a/EvtWeightTools/src/Data_to_MC_CorrectionInterface_trigger_Base.cc
+++ b/EvtWeightTools/src/Data_to_MC_CorrectionInterface_trigger_Base.cc
@@ -113,7 +113,8 @@ Data_to_MC_CorrectionInterface_trigger_Base::tau_leg_efficiency(double pt,
                                                                const std::string & data_type,
                                                                const std::string & sys) const
 {
-  return sf_trigger_->evaluate({ std::max(pt, tau_trigger_ptThresholds_.at(trigger_type)), dm, trigger_type, wp, data_type, sys });
+  const double pt_threshold = tau_trigger_ptThresholds_.at(trigger_type);
+  return pt >= pt_threshold ? sf_trigger_->evaluate({ pt, dm, trigger_type, wp, data_type, sys }) : 0.;
 }
 
 TauTriggerSFValues

--- a/EvtWeightTools/src/EvtWeightRecorder.cc
+++ b/EvtWeightTools/src/EvtWeightRecorder.cc
@@ -3,13 +3,10 @@
 #include "TallinnNtupleProducer/CommonTools/interface/cmsException.h"                                      // cmsException()
 #include "TallinnNtupleProducer/CommonTools/interface/sysUncertOptions.h"                                  // EWKJetSys, EWKBJetSys, getJetToLeptonFR_option(), getJetToTauFR_option(), kFRjt_central, kFRl_central, TriggerSFsysChoice
 #include "TallinnNtupleProducer/EvtWeightTools/interface/Data_to_MC_CorrectionInterface_Base.h"            // Data_to_MC_CorrectionInterface_Base
-#include "TallinnNtupleProducer/EvtWeightTools/interface/Data_to_MC_CorrectionInterface_0l_2tau_trigger.h" // Data_to_MC_CorrectionInterface_0l_2tau_trigger
-#include "TallinnNtupleProducer/EvtWeightTools/interface/Data_to_MC_CorrectionInterface_1l_1tau_trigger.h" // Data_to_MC_CorrectionInterface_1l_1tau_trigger
-#include "TallinnNtupleProducer/EvtWeightTools/interface/Data_to_MC_CorrectionInterface_1l_2tau_trigger.h" // Data_to_MC_CorrectionInterface_1l_2tau_trigger
+#include "TallinnNtupleProducer/EvtWeightTools/interface/Data_to_MC_CorrectionInterface_trigger_Base.h"    // Data_to_MC_CorrectionInterface_trigger_Base
 #include "TallinnNtupleProducer/EvtWeightTools/interface/DYMCNormScaleFactors.h"                           // DYMCNormScaleFactors
 #include "TallinnNtupleProducer/EvtWeightTools/interface/DYMCReweighting.h"                                // DYMCReweighting
 #include "TallinnNtupleProducer/EvtWeightTools/interface/EvtWeightManager.h"                               // EvtWeightManager
-#include "TallinnNtupleProducer/EvtWeightTools/interface/fakeBackgroundAuxFunctions.h"                     // getWeight_1L(), getWeight_2L(), getWeight_3L(),getWeight_4L()
 #include "TallinnNtupleProducer/EvtWeightTools/interface/HadTauFakeRateInterface.h"                        // HadTauFakeRateInterface
 #include "TallinnNtupleProducer/EvtWeightTools/interface/HHWeightInterfaceLO.h"                            // HHWeightInterfaceLO
 #include "TallinnNtupleProducer/EvtWeightTools/interface/HHWeightInterfaceNLO.h"                           // HHWeightInterfaceNLO
@@ -1043,7 +1040,7 @@ EvtWeightRecorder::record_leptonTriggerEff(const Data_to_MC_CorrectionInterface_
 }
 
 void
-EvtWeightRecorder::record_tauTriggerEff(const Data_to_MC_CorrectionInterface_0l_2tau_trigger * const dataToMCcorrectionInterface_0l_2tau_trigger)
+EvtWeightRecorder::record_tauTriggerEff(const Data_to_MC_CorrectionInterface_trigger_Base * const dataToMCcorrectionInterface_trigger)
 {
   assert(isMC_);
   weights_tauTriggerEff_.clear();
@@ -1054,39 +1051,7 @@ EvtWeightRecorder::record_tauTriggerEff(const Data_to_MC_CorrectionInterface_0l_
     {
       continue;
     }
-    weights_tauTriggerEff_[triggerSF_option] = dataToMCcorrectionInterface_0l_2tau_trigger->getSF_triggerEff(triggerSF_option);
-  }
-}
-
-void
-EvtWeightRecorder::record_tauTriggerEff(const Data_to_MC_CorrectionInterface_1l_1tau_trigger * const dataToMCcorrectionInterface_1l_1tau_trigger)
-{
-  assert(isMC_);
-  weights_tauTriggerEff_.clear();
-  for(const std::string & central_or_shift: central_or_shifts_)
-  {
-    const TriggerSFsys triggerSF_option = getTriggerSF_option(central_or_shift, TriggerSFsysChoice::hadTauOnly);
-    if(weights_tauTriggerEff_.count(triggerSF_option))
-    {
-      continue;
-    }
-    weights_tauTriggerEff_[triggerSF_option] = dataToMCcorrectionInterface_1l_1tau_trigger->getSF_triggerEff(triggerSF_option);
-  }
-}
-
-void
-EvtWeightRecorder::record_tauTriggerEff(const Data_to_MC_CorrectionInterface_1l_2tau_trigger * const dataToMCcorrectionInterface_1l_2tau_trigger)
-{
-  assert(isMC_);
-  weights_tauTriggerEff_.clear();
-  for(const std::string & central_or_shift: central_or_shifts_)
-  {
-    const TriggerSFsys triggerSF_option = getTriggerSF_option(central_or_shift, TriggerSFsysChoice::hadTauOnly);
-    if(weights_tauTriggerEff_.count(triggerSF_option))
-    {
-      continue;
-    }
-    weights_tauTriggerEff_[triggerSF_option] = dataToMCcorrectionInterface_1l_2tau_trigger->getSF_triggerEff(triggerSF_option);
+    weights_tauTriggerEff_[triggerSF_option] = dataToMCcorrectionInterface_trigger->getSF_triggerEff(triggerSF_option);
   }
 }
 

--- a/EvtWeightTools/src/data_to_MC_corrections_auxFunctions.cc
+++ b/EvtWeightTools/src/data_to_MC_corrections_auxFunctions.cc
@@ -154,7 +154,7 @@ namespace aux
   {
     if(eff_data == 0. && eff_mc == 0.)
     {
-      std::cout << "WARNING: efficiency in data and in MC are both zero -> returning SF = 1 instead\n";
+      //std::cout << "WARNING: efficiency in data and in MC are both zero -> returning SF = 1 instead\n";
       return 1.;
     }
     return std::min(eff_data / std::max(1.e-6, eff_mc), 1.e+1);
@@ -171,14 +171,12 @@ namespace aux
     {
       case TriggerSFsys::central:            return aux::compSF(eff_data.central, eff_mc.central);
       case TriggerSFsys::shiftUp:            __attribute__((fallthrough));
-      case TriggerSFsys::shift_2lssUp:       __attribute__((fallthrough));
       case TriggerSFsys::shift_2lssEEUp:     __attribute__((fallthrough));
       case TriggerSFsys::shift_2lssEMuUp:    __attribute__((fallthrough));
       case TriggerSFsys::shift_2lssMuMuUp:   __attribute__((fallthrough));
       case TriggerSFsys::shift_1l1tauUp:     __attribute__((fallthrough));
       case TriggerSFsys::shift_0l2tauUp:     return aux::compSF(eff_data.max, eff_mc.min);
       case TriggerSFsys::shiftDown:          __attribute__((fallthrough));
-      case TriggerSFsys::shift_2lssDown:     __attribute__((fallthrough));
       case TriggerSFsys::shift_2lssEEDown:   __attribute__((fallthrough));
       case TriggerSFsys::shift_2lssEMuDown:  __attribute__((fallthrough));
       case TriggerSFsys::shift_2lssMuMuDown: __attribute__((fallthrough));
@@ -571,32 +569,6 @@ namespace aux
         16., 100., lut::kLimit, etaMin, etaMax, lut::kCut
       ));
     }
-  }
-
-  double
-  tau_leg_efficiency(const double pt, 
-                     const int dm, 
-                     const std::string trigger_type, 
-                     const std::string wp, 
-                     const std::string data_type, 
-                     const correction::Correction::Ref cset,
-                     const std::string & sys)
-  {
-    return cset->evaluate({ pt, dm, trigger_type, wp, data_type, sys });
-  }
-
-  TauTriggerSFValues
-  tau_leg_efficiency(const double pt, 
-                     const int dm, 
-                     const std::string trigger_type, 
-                     const std::string wp, 
-                     const std::string data_type, 
-                     const correction::Correction::Ref cset)
-  {
-    const double nom = tau_leg_efficiency(pt, dm, trigger_type, wp, data_type, cset, "nom");
-    const double up = tau_leg_efficiency(pt, dm, trigger_type, wp, data_type, cset, "up");
-    const double down = tau_leg_efficiency(pt, dm, trigger_type, wp, data_type, cset, "down");
-    return { down, nom, up };
   }
 
   int

--- a/Framework/bin/produceNtuple.cc
+++ b/Framework/bin/produceNtuple.cc
@@ -7,54 +7,58 @@
  *
  */
 
-#include "DataFormats/FWLite/interface/InputSource.h"                                           // fwlite::InputSource
-#include "DataFormats/FWLite/interface/OutputFiles.h"                                           // fwlite::OutputFiles
-#include "FWCore/ParameterSet/interface/ParameterSet.h"                                         // edm::ParameterSet
-#include "FWCore/ParameterSetReader/interface/ParameterSetReader.h"                             // edm::readPSetsFrom()
-#include "FWCore/PluginManager/interface/PluginManager.h"                                       // edmplugin::PluginManager::configure()
-#include "FWCore/PluginManager/interface/standard.h"                                            // edmplugin::standard::config()
-#include "PhysicsTools/FWLite/interface/TFileService.h"                                         // fwlite::TFileService
+#include "DataFormats/FWLite/interface/InputSource.h"                                                      // fwlite::InputSource
+#include "DataFormats/FWLite/interface/OutputFiles.h"                                                      // fwlite::OutputFiles
+#include "FWCore/ParameterSet/interface/ParameterSet.h"                                                    // edm::ParameterSet
+#include "FWCore/ParameterSetReader/interface/ParameterSetReader.h"                                        // edm::readPSetsFrom()
+#include "FWCore/PluginManager/interface/PluginManager.h"                                                  // edmplugin::PluginManager::configure()
+#include "FWCore/PluginManager/interface/standard.h"                                                       // edmplugin::standard::config()
+#include "PhysicsTools/FWLite/interface/TFileService.h"                                                    // fwlite::TFileService
 
-#include "TallinnNtupleProducer/CommonTools/interface/memory_logger.h"                          // log_memory(), display_memory()
-#include "TallinnNtupleProducer/CommonTools/interface/cmsException.h"                           // cmsException
-#include "TallinnNtupleProducer/CommonTools/interface/Era.h"                                    // Era, get_era()
-#include "TallinnNtupleProducer/CommonTools/interface/contains.h"                               // contains()
-#include "TallinnNtupleProducer/CommonTools/interface/format_vT.h"                              // format_vstring()
-#include "TallinnNtupleProducer/CommonTools/interface/hadTauDefinitions.h"                      // get_tau_id_wp_int()
-#include "TallinnNtupleProducer/CommonTools/interface/merge_systematic_shifts.h"                // merge_systematic_shifts()
-#include "TallinnNtupleProducer/CommonTools/interface/TTreeWrapper.h"                           // TTreeWrapper
-#include "TallinnNtupleProducer/EvtWeightTools/interface/ChargeMisIdRateInterface.h"            // ChargeMisIdRateInterface
-#include "TallinnNtupleProducer/EvtWeightTools/interface/Data_to_MC_CorrectionInterface_2016.h" // Data_to_MC_CorrectionInterface_2016
-#include "TallinnNtupleProducer/EvtWeightTools/interface/Data_to_MC_CorrectionInterface_2017.h" // Data_to_MC_CorrectionInterface_2017
-#include "TallinnNtupleProducer/EvtWeightTools/interface/Data_to_MC_CorrectionInterface_2018.h" // Data_to_MC_CorrectionInterface_2018
-#include "TallinnNtupleProducer/EvtWeightTools/interface/DYMCReweighting.h"                     // DYMCReweighting
-#include "TallinnNtupleProducer/EvtWeightTools/interface/DYMCNormScaleFactors.h"                // DYMCNormScaleFactors
-#include "TallinnNtupleProducer/EvtWeightTools/interface/EvtWeightManager.h"                    // EvtWeightManager
-#include "TallinnNtupleProducer/EvtWeightTools/interface/EvtWeightRecorder.h"                   // EvtWeightRecorder
-#include "TallinnNtupleProducer/EvtWeightTools/interface/HadTauFakeRateInterface.h"             // HadTauFakeRateInterface
-#include "TallinnNtupleProducer/EvtWeightTools/interface/LeptonFakeRateInterface.h"             // LeptonFakeRateInterface
-#include "TallinnNtupleProducer/EvtWeightTools/interface/LHEVpt_LOtoNLO.h"                      // LHEVpt_LOtoNLO
-#include "TallinnNtupleProducer/Objects/interface/Event.h"                                      // Event
-#include "TallinnNtupleProducer/Objects/interface/EventInfo.h"                                  // EventInfo
-#include "TallinnNtupleProducer/Objects/interface/RunLumiEvent.h"                               // RunLumiEvent
-#include "TallinnNtupleProducer/Readers/interface/EventReader.h"                                // EventReader
-#include "TallinnNtupleProducer/Readers/interface/L1PreFiringWeightReader.h"                    // L1PreFiringWeightReader
-#include "TallinnNtupleProducer/Readers/interface/LHEInfoReader.h"                              // LHEInfoReader
+#include "TallinnNtupleProducer/CommonTools/interface/memory_logger.h"                                     // log_memory(), display_memory()
+#include "TallinnNtupleProducer/CommonTools/interface/cmsException.h"                                      // cmsException
+#include "TallinnNtupleProducer/CommonTools/interface/Era.h"                                               // Era, get_era()
+#include "TallinnNtupleProducer/CommonTools/interface/contains.h"                                          // contains()
+#include "TallinnNtupleProducer/CommonTools/interface/format_vT.h"                                         // format_vstring()
+#include "TallinnNtupleProducer/CommonTools/interface/hadTauDefinitions.h"                                 // get_tau_id_wp_int()
+#include "TallinnNtupleProducer/CommonTools/interface/merge_systematic_shifts.h"                           // merge_systematic_shifts()
+#include "TallinnNtupleProducer/CommonTools/interface/TTreeWrapper.h"                                      // TTreeWrapper
+#include "TallinnNtupleProducer/EvtWeightTools/interface/ChargeMisIdRateInterface.h"                       // ChargeMisIdRateInterface
+#include "TallinnNtupleProducer/EvtWeightTools/interface/Data_to_MC_CorrectionInterface_2016.h"            // Data_to_MC_CorrectionInterface_2016
+#include "TallinnNtupleProducer/EvtWeightTools/interface/Data_to_MC_CorrectionInterface_2017.h"            // Data_to_MC_CorrectionInterface_2017
+#include "TallinnNtupleProducer/EvtWeightTools/interface/Data_to_MC_CorrectionInterface_2018.h"            // Data_to_MC_CorrectionInterface_2018
+#include "TallinnNtupleProducer/EvtWeightTools/interface/Data_to_MC_CorrectionInterface_0l_4tau_trigger.h" // Data_to_MC_CorrectionInterface_0l_4tau_trigger, Data_to_MC_CorrectionInterface_0l_2tau_trigger
+#include "TallinnNtupleProducer/EvtWeightTools/interface/Data_to_MC_CorrectionInterface_1l_3tau_trigger.h" // Data_to_MC_CorrectionInterface_1l_3tau_trigger, Data_to_MC_CorrectionInterface_1l_2tau_trigger
+#include "TallinnNtupleProducer/EvtWeightTools/interface/Data_to_MC_CorrectionInterface_1l_1tau_trigger.h" // Data_to_MC_CorrectionInterface_1l_1tau_trigger
+#include "TallinnNtupleProducer/EvtWeightTools/interface/DYMCReweighting.h"                                // DYMCReweighting
+#include "TallinnNtupleProducer/EvtWeightTools/interface/DYMCNormScaleFactors.h"                           // DYMCNormScaleFactors
+#include "TallinnNtupleProducer/EvtWeightTools/interface/EvtWeightManager.h"                               // EvtWeightManager
+#include "TallinnNtupleProducer/EvtWeightTools/interface/EvtWeightRecorder.h"                              // EvtWeightRecorder
+#include "TallinnNtupleProducer/EvtWeightTools/interface/HadTauFakeRateInterface.h"                        // HadTauFakeRateInterface
+#include "TallinnNtupleProducer/EvtWeightTools/interface/LeptonFakeRateInterface.h"                        // LeptonFakeRateInterface
+#include "TallinnNtupleProducer/EvtWeightTools/interface/LHEVpt_LOtoNLO.h"                                 // LHEVpt_LOtoNLO
+#include "TallinnNtupleProducer/Objects/interface/Event.h"                                                 // Event
+#include "TallinnNtupleProducer/Objects/interface/EventInfo.h"                                             // EventInfo
+#include "TallinnNtupleProducer/Objects/interface/RunLumiEvent.h"                                          // RunLumiEvent
+#include "TallinnNtupleProducer/Readers/interface/EventReader.h"                                           // EventReader
+#include "TallinnNtupleProducer/Readers/interface/L1PreFiringWeightReader.h"                               // L1PreFiringWeightReader
+#include "TallinnNtupleProducer/Readers/interface/LHEInfoReader.h"                                         // LHEInfoReader
 #include "TallinnNtupleProducer/Readers/interface/LHEParticleReader.h"
-#include "TallinnNtupleProducer/Readers/interface/PSWeightReader.h"                             // PSWeightReader
-#include "TallinnNtupleProducer/Selectors/interface/RunLumiEventSelector.h"                     // RunLumiEventSelector
-#include "TallinnNtupleProducer/Writers/interface/WriterBase.h"                                 // WriterBase, WriterPluginFactory
-#include <TBenchmark.h>                                                                         // TBenchmark
-#include <TError.h>                                                                             // gErrorAbortLevel, kError
-#include <TString.h>                                                                            // TString, Form()
-#include <TTree.h>                                                                              // TTree
+#include "TallinnNtupleProducer/Readers/interface/PSWeightReader.h"                                        // PSWeightReader
+#include "TallinnNtupleProducer/Selectors/interface/RunLumiEventSelector.h"                                // RunLumiEventSelector
+#include "TallinnNtupleProducer/Writers/interface/WriterBase.h"                                            // WriterBase, WriterPluginFactory
+
+#include <TBenchmark.h>                                                                                    // TBenchmark
+#include <TError.h>                                                                                        // gErrorAbortLevel, kError
+#include <TString.h>                                                                                       // TString, Form()
+#include <TTree.h>                                                                                         // TTree
 
 #include "correction.h"
-#include <assert.h>                                                                             // assert()
-#include <cstdlib>                                                                              // EXIT_SUCCESS, EXIT_FAILURE
-#include <iostream>                                                                             // std::cout
-#include <string>                                                                               // std::string
-#include <vector>                                                                               // std::vector
+#include <assert.h>                                                                                        // assert()
+#include <cstdlib>                                                                                         // EXIT_SUCCESS, EXIT_FAILURE
+#include <iostream>                                                                                        // std::cout
+#include <string>                                                                                          // std::string
+#include <vector>                                                                                          // std::vector
 
 typedef std::vector<std::string> vstring;
 
@@ -160,6 +164,8 @@ int main(int argc, char* argv[])
 
   edm::ParameterSet cfg_dataToMCcorrectionInterface;
   cfg_dataToMCcorrectionInterface.addParameter<std::string>("era", era_string);
+  cfg_dataToMCcorrectionInterface.addParameter<unsigned>("numNominalLeptons", numNominalLeptons);
+  cfg_dataToMCcorrectionInterface.addParameter<unsigned>("numNominalHadTaus", numNominalHadTaus);
   cfg_dataToMCcorrectionInterface.addParameter<std::string>("hadTauSelection_againstJets", hadTauWP_againstJets);
   cfg_dataToMCcorrectionInterface.addParameter<int>("hadTauSelection_againstElectrons", get_tau_id_wp_int(hadTauWP_againstElectrons));
   cfg_dataToMCcorrectionInterface.addParameter<int>("hadTauSelection_againstMuons", get_tau_id_wp_int(hadTauWP_againstMuons));
@@ -176,6 +182,29 @@ int main(int argc, char* argv[])
     case Era::kUndefined: __attribute__((fallthrough));
     default: throw cmsException("produceNtuple", __LINE__) << "Invalid era = " << static_cast<int>(era);
   }
+
+  Data_to_MC_CorrectionInterface_trigger_Base * dataToMCcorrectionInterface_trigger = nullptr;
+  if(numNominalLeptons == 0 && numNominalHadTaus == 4)
+  {
+    dataToMCcorrectionInterface_trigger = new Data_to_MC_CorrectionInterface_0l_4tau_trigger(cfg_dataToMCcorrectionInterface);
+  }
+  else if(numNominalLeptons == 1 && numNominalHadTaus == 3)
+  {
+    dataToMCcorrectionInterface_trigger = new Data_to_MC_CorrectionInterface_1l_3tau_trigger(cfg_dataToMCcorrectionInterface);
+  }
+  else if(numNominalLeptons == 0 && numNominalHadTaus == 2)
+  {
+    dataToMCcorrectionInterface_trigger = new Data_to_MC_CorrectionInterface_0l_2tau_trigger(cfg_dataToMCcorrectionInterface);
+  }
+  else if(numNominalLeptons == 1 && numNominalHadTaus == 1)
+  {
+    dataToMCcorrectionInterface_trigger = new Data_to_MC_CorrectionInterface_1l_1tau_trigger(cfg_dataToMCcorrectionInterface);
+  }
+  else if(numNominalLeptons == 1 && numNominalHadTaus == 2)
+  {
+    dataToMCcorrectionInterface_trigger = new Data_to_MC_CorrectionInterface_1l_2tau_trigger(cfg_dataToMCcorrectionInterface);
+  }
+
   const ChargeMisIdRateInterface chargeMisIdRateInterface(era);
 
   edm::ParameterSet cfg_leptonFakeRateWeight = cfg_produceNtuple.getParameterSet("leptonFakeRateWeight");
@@ -458,14 +487,27 @@ int main(int argc, char* argv[])
         dataToMCcorrectionInterface->setLeptons(event.fakeableLeptons(), true);
 
 //--- apply data/MC corrections for trigger efficiency
-        evtWeightRecorder.record_leptonTriggerEff(dataToMCcorrectionInterface);
+        if(event.fakeableLeptons().size() == numNominalLeptons)
+        {
+          evtWeightRecorder.record_leptonTriggerEff(dataToMCcorrectionInterface);
+        }
+        if(dataToMCcorrectionInterface_trigger)
+        {
+          dataToMCcorrectionInterface_trigger->setHadTaus(event.fakeableHadTaus());
+          dataToMCcorrectionInterface_trigger->setLeptons(event.fakeableLeptons());
+          if(event.fakeableLeptons().size() == numNominalLeptons &&
+             event.fakeableHadTaus().size() == numNominalHadTaus  )
+          {
+            evtWeightRecorder.record_tauTriggerEff(dataToMCcorrectionInterface_trigger);
+          }
+        }
 
 //--- apply data/MC corrections for efficiencies for lepton to pass loose identification and isolation criteria
         evtWeightRecorder.record_leptonIDSF_recoToLoose(dataToMCcorrectionInterface);
 
 //--- apply data/MC corrections for efficiencies of leptons passing the loose identification and isolation criteria
 //    to also pass the fakeable and/or tight identification and isolation criteria
-        evtWeightRecorder.record_leptonIDSF_looseToTight(dataToMCcorrectionInterface, false);
+        evtWeightRecorder.record_leptonIDSF_looseToTight(dataToMCcorrectionInterface, apply_chargeMisIdRate);
 
 //--- apply data/MC corrections for hadronic tau identification efficiency
 //    and for e->tau and mu->tau misidentification rates

--- a/Writers/plugins/EvtWeightWriter.cc
+++ b/Writers/plugins/EvtWeightWriter.cc
@@ -123,18 +123,32 @@ EvtWeightWriter::get_supported_systematics(const edm::ParameterSet & cfg)
         }
         merge_systematic_shifts(supported_systematics, pdf_member_sys);
       }
-      if(cfg.getParameter<unsigned>("numNominalLeptons") > 0)
+      const unsigned numNominalLeptons = cfg.getParameter<unsigned>("numNominalLeptons");
+      if(numNominalLeptons > 0)
       {
         merge_systematic_shifts(supported_systematics, map_keys(leptonIDSFSysMap));
         merge_systematic_shifts(supported_systematics, map_keys(jetToLeptonFRSysMap));
       }
-      if(cfg.getParameter<unsigned>("numNominalHadTaus") > 0)
+      const unsigned numNominalHadTaus = cfg.getParameter<unsigned>("numNominalHadTaus");
+      if(numNominalHadTaus > 0)
       {
         merge_systematic_shifts(supported_systematics, map_keys(jetToTauFRSysMap));
         merge_systematic_shifts(supported_systematics, map_keys(eToTauFRSysMap));
         merge_systematic_shifts(supported_systematics, map_keys(mToTauFRSysMap));
         merge_systematic_shifts(supported_systematics, map_keys(tauIDSFSysMap));
       }
+
+      merge_systematic_shifts(supported_systematics, map_keys(triggerSFSysMap));
+      if(numNominalLeptons == 1 && numNominalHadTaus == 3)
+      {
+        merge_systematic_shifts(supported_systematics, map_keys(triggerSFSysMap_0l_2tau));
+        merge_systematic_shifts(supported_systematics, map_keys(triggerSFSysMap_1l_1tau));
+      }
+      if(numNominalLeptons == 2 && numNominalHadTaus <= 2)
+      {
+        merge_systematic_shifts(supported_systematics, map_keys(triggerSFSysMap_2lss));
+      }
+
       if(cfg.getParameter<bool>("apply_DYMCReweighting"))
       {
         merge_systematic_shifts(supported_systematics, map_keys(dyMCRwgtSysMap));
@@ -152,7 +166,7 @@ EvtWeightWriter::get_supported_systematics(const edm::ParameterSet & cfg)
         merge_systematic_shifts(supported_systematics, map_keys(ewkJetSysMap));
         merge_systematic_shifts(supported_systematics, map_keys(ewkBJetSysMap));
       }
-      //TODO: trigger SF, subjet b-tagging SF, Vpt
+      //TODO: subjet b-tagging SF, Vpt
     }
   }
   return supported_systematics;


### PR DESCRIPTION
Resolves https://github.com/HEP-KBFI/TallinnNtupleProducer/issues/17. Tested 2lss+1tau and 1l+1tau.

The trigger SF depend on the reconstructed lepton and taus but their number is not guaranteed to pass the nominal cut, which could result in "undefined" behavior. In order to avoid computing bogus SF, I've placed the trigger SF computation under these if blocks:
https://github.com/HEP-KBFI/TallinnNtupleProducer/blob/288ddb7a2f8115bbfc9add1c97190591787e9840/Framework/bin/produceNtuple.cc#L482-L495

In other words, the trigger SF are calculated only if the number of fakeable leptons and taus matches their nominal number.