### PR TITLE
Trigger sf

### DIFF
--- a/EvtWeightTools/interface/Data_to_MC_CorrectionInterface_0l_4tau_trigger.h
+++ b/EvtWeightTools/interface/Data_to_MC_CorrectionInterface_0l_4tau_trigger.h
@@ -21,15 +21,6 @@ protected:
   bool
   check_triggerSFsys_opt(TriggerSFsys central_or_shift) const;
 
-  // define states of tau leg of ditau trigger for each reconstructed tau
-  enum { k2tau, kNot2tau };
-
-  // define auxiliary functions
-  double
-  getProb_tau(int tau_status,
-              double eff_2tau_tauLeg) const;
-
-  //-----------------------------------------------------------------------------
   // data/MC corrections for trigger efficiencies in 2017 ReReco data and Summer17 MC
 
 };

--- a/EvtWeightTools/interface/Data_to_MC_CorrectionInterface_trigger_Base.h
+++ b/EvtWeightTools/interface/Data_to_MC_CorrectionInterface_trigger_Base.h
@@ -98,6 +98,8 @@ class Data_to_MC_CorrectionInterface_trigger_Base
   const TauID tauId_;
   const std::string wp_str_;
 
+  std::vector<const RecoHadTau*> hadTau_recObjs;
+
   std::unique_ptr<correction::CorrectionSet> tau_tigger_cset_;
   correction::Correction::Ref sf_trigger_;
   //-----------------------------------------------------------------------------

--- a/EvtWeightTools/src/Data_to_MC_CorrectionInterface_0l_4tau_trigger.cc
+++ b/EvtWeightTools/src/Data_to_MC_CorrectionInterface_0l_4tau_trigger.cc
@@ -1,8 +1,6 @@
-#include <DataFormats/Math/interface/deltaR.h>                        // deltaR()
-#include "TallinnNtupleProducer/Objects/interface/RecoHadTau.h"       // RecoHadTau::filterBits()
 #include "TallinnNtupleProducer/EvtWeightTools/interface/Data_to_MC_CorrectionInterface_0l_4tau_trigger.h"
 #include "TallinnNtupleProducer/EvtWeightTools/interface/data_to_MC_corrections_auxFunctions.h" // aux::
-
+#include "TallinnNtupleProducer/Objects/interface/RecoHadTau.h"                                 // RecoHadTau::filterBits()
 #include "TallinnNtupleProducer/CommonTools/interface/cmsException.h"                           // cmsException()
 #include "TallinnNtupleProducer/CommonTools/interface/sysUncertOptions.h"                       // TriggerSFsys, getTriggerSF_option()
 

--- a/EvtWeightTools/src/Data_to_MC_CorrectionInterface_0l_4tau_trigger.cc
+++ b/EvtWeightTools/src/Data_to_MC_CorrectionInterface_0l_4tau_trigger.cc
@@ -1,8 +1,10 @@
+#include <DataFormats/Math/interface/deltaR.h>                        // deltaR()
+#include "TallinnNtupleProducer/Objects/interface/RecoHadTau.h"       // RecoHadTau::filterBits()
 #include "TallinnNtupleProducer/EvtWeightTools/interface/Data_to_MC_CorrectionInterface_0l_4tau_trigger.h"
+#include "TallinnNtupleProducer/EvtWeightTools/interface/data_to_MC_corrections_auxFunctions.h" // aux::
 
 #include "TallinnNtupleProducer/CommonTools/interface/cmsException.h"                           // cmsException()
 #include "TallinnNtupleProducer/CommonTools/interface/sysUncertOptions.h"                       // TriggerSFsys, getTriggerSF_option()
-#include "TallinnNtupleProducer/EvtWeightTools/interface/data_to_MC_corrections_auxFunctions.h" // aux::
 
 #include <TString.h> // Form()
 
@@ -40,115 +42,27 @@ Data_to_MC_CorrectionInterface_0l_4tau_trigger::getSF_triggerEff(TriggerSFsys ce
     sys = "down";
   }
 
-  double eff_2tau_tauLeg1_data = 0.;
-  double eff_2tau_tauLeg1_mc   = 0.;
-  double eff_2tau_tauLeg2_data = 0.;
-  double eff_2tau_tauLeg2_mc   = 0.;
-  double eff_2tau_tauLeg3_data = 0.;
-  double eff_2tau_tauLeg3_mc   = 0.;
-  double eff_2tau_tauLeg4_data = 0.;
-  double eff_2tau_tauLeg4_mc   = 0.;
+  std::vector<const RecoHadTau*> matched_hadTaus;
 
-  if(std::fabs(hadTau1_eta_) <= 2.1 && aux::hasDecayMode(allowedDecayModes_, hadTau1_decayMode_))
+  for (auto hadTau_recObj : hadTau_recObjs)
   {
-    eff_2tau_tauLeg1_data = tau_leg_efficiency(hadTau1_pt_, hadTau1_decayMode_, "ditau", wp_str_, "eff_data", sys);
-    eff_2tau_tauLeg1_mc   = tau_leg_efficiency(hadTau1_pt_, hadTau1_decayMode_, "ditau", wp_str_, "eff_mc", sys);
+    //can we use 64, 128 filterbits only as they are related to di-tau trigger
+    //https://cmssdt.cern.ch/lxr/source/PhysicsTools/NanoAOD/python/triggerObjects_cff.py?v=CMSSW_12_6_X_2022-09-08-2300 #Line-0122
+    if ( hadTau_recObj->filterBits() ) matched_hadTaus.push_back(hadTau_recObj);
   }
 
-  if(std::fabs(hadTau2_eta_) <= 2.1 && aux::hasDecayMode(allowedDecayModes_, hadTau2_decayMode_))
+  double prob_data(1);
+  double prob_mc(1);
+  for( auto matched_hadTau : matched_hadTaus)
   {
-    eff_2tau_tauLeg2_data = tau_leg_efficiency(hadTau2_pt_, hadTau2_decayMode_, "ditau", wp_str_, "eff_data", sys);
-    eff_2tau_tauLeg2_mc   = tau_leg_efficiency(hadTau2_pt_, hadTau2_decayMode_, "ditau", wp_str_, "eff_mc", sys);
+    prob_data *= tau_leg_efficiency(matched_hadTau->pt(), matched_hadTau->decayMode(), "ditau", wp_str_, "eff_data", sys);
+    prob_mc *= tau_leg_efficiency(matched_hadTau->pt(), matched_hadTau->decayMode(), "ditau", wp_str_, "eff_mc", sys);
   }
 
-  if(std::fabs(hadTau3_eta_) <= 2.1 && aux::hasDecayMode(allowedDecayModes_, hadTau3_decayMode_))
-  {
-    eff_2tau_tauLeg3_data = tau_leg_efficiency(hadTau3_pt_, hadTau2_decayMode_, "ditau", wp_str_, "eff_data", sys);
-    eff_2tau_tauLeg3_mc   = tau_leg_efficiency(hadTau3_pt_, hadTau3_decayMode_, "ditau", wp_str_, "eff_mc", sys);
-  }
-
-  if(std::fabs(hadTau4_eta_) <= 2.1 && aux::hasDecayMode(allowedDecayModes_, hadTau4_decayMode_))
-  {
-    eff_2tau_tauLeg4_data = tau_leg_efficiency(hadTau4_pt_, hadTau4_decayMode_, "ditau", wp_str_, "eff_data", sys);
-    eff_2tau_tauLeg4_mc   = tau_leg_efficiency(hadTau4_pt_, hadTau4_decayMode_, "ditau", wp_str_, "eff_mc", sys);
-  }
-
-  double prob_data = 0.;
-  double prob_mc   = 0.;
-
-  for(int tau1_status = k2tau; tau1_status <= kNot2tau; ++tau1_status)
-  {
-    const double prob_tau1_data = getProb_tau(tau1_status, eff_2tau_tauLeg1_data);
-    const double prob_tau1_mc   = getProb_tau(tau1_status, eff_2tau_tauLeg1_mc);
-
-    for(int tau2_status = k2tau; tau2_status <= kNot2tau; ++tau2_status)
-    {
-      const double prob_tau2_data = getProb_tau(tau2_status, eff_2tau_tauLeg2_data);
-      const double prob_tau2_mc   = getProb_tau(tau2_status, eff_2tau_tauLeg2_mc);
-
-      for(int tau3_status = k2tau; tau3_status <= kNot2tau; ++tau3_status)
-      {
-        const double prob_tau3_data = getProb_tau(tau3_status, eff_2tau_tauLeg3_data);
-        const double prob_tau3_mc   = getProb_tau(tau3_status, eff_2tau_tauLeg3_mc);
-
-        for(int tau4_status = k2tau; tau4_status <= kNot2tau; ++tau4_status)
-        {
-          const double prob_tau4_data = getProb_tau(tau4_status, eff_2tau_tauLeg4_data);
-          const double prob_tau4_mc   = getProb_tau(tau4_status, eff_2tau_tauLeg4_mc);
-
-          int nTrig_2tau_tauLeg = 0;
-          if(tau1_status == k2tau)
-          {
-            ++nTrig_2tau_tauLeg;
-          }
-          if(tau2_status == k2tau)
-          {
-            ++nTrig_2tau_tauLeg;
-          }
-          if(tau3_status == k2tau)
-          {
-            ++nTrig_2tau_tauLeg;
-          }
-          if(tau4_status == k2tau)
-          {
-            ++nTrig_2tau_tauLeg;
-          }
-
-          const bool isTrig_2tau_toy = nTrig_2tau_tauLeg >= 2;
-
-          if(isTriggered_2tau_ == isTrig_2tau_toy)
-          {
-            prob_data += prob_tau1_data * prob_tau2_data * prob_tau3_data * prob_tau4_data;
-            prob_mc   += prob_tau1_mc   * prob_tau2_mc   * prob_tau3_mc   * prob_tau4_mc;
-          }
-        }
-      }
-    }
-  }
-
-  if(isDEBUG_)
-  {
-    std::cout << "hadTau (lead):    pT = " << hadTau1_pt_ << ", eta = " << hadTau1_eta_ << "\n"
-                 "hadTau (sublead): pT = " << hadTau2_pt_ << ", eta = " << hadTau2_eta_ << "\n"
-                 "hadTau (third):   pT = " << hadTau3_pt_ << ", eta = " << hadTau3_eta_ << "\n"
-                 "hadTau (fourth):  pT = " << hadTau4_pt_ << ", eta = " << hadTau4_eta_ << "\n"
-                 "eff (X_tau1): data = " << eff_2tau_tauLeg1_data   << ", MC = " << eff_2tau_tauLeg1_mc   << "\n"
-                 "eff (X_tau2): data = " << eff_2tau_tauLeg2_data   << ", MC = " << eff_2tau_tauLeg2_mc   << "\n"
-                 "eff (X_tau3): data = " << eff_2tau_tauLeg3_data   << ", MC = " << eff_2tau_tauLeg3_mc   << "\n"
-                 "eff (X_tau4): data = " << eff_2tau_tauLeg4_data   << ", MC = " << eff_2tau_tauLeg4_mc   << '\n'
-    ;
-  }
+  if ( isDEBUG_ )
+    std::cout << "prob_data: " << prob_data << "\t prob_mc: " << prob_mc << std::endl;
 
   const double sf = aux::compSF(prob_data, prob_mc);
-  if(isDEBUG_)
-  {
-    const int idxCase = isTriggered_2tau_ ? 1 : 0;
-    const std::string text_2tau = isTriggered_2tau_ ? "ditau trigger doesn't fire" : "ditau trigger fires";
-    std::cout << "case " << idxCase << ": " << text_2tau << "\n"
-                 " eff: data = " << prob_data << ", MC = " << prob_mc << " --> SF = " << sf << '\n'
-    ;
-  }
-
   return sf;
 }
  

--- a/EvtWeightTools/src/Data_to_MC_CorrectionInterface_0l_4tau_trigger.cc
+++ b/EvtWeightTools/src/Data_to_MC_CorrectionInterface_0l_4tau_trigger.cc
@@ -49,8 +49,6 @@ Data_to_MC_CorrectionInterface_0l_4tau_trigger::getSF_triggerEff(TriggerSFsys ce
     if ( hadTau_recObj->filterBits() ) matched_hadTaus.push_back(hadTau_recObj);
   }
 
-  assert( matched_hadTaus.size() >= 2 );
-
   double prob_data(1);
   double prob_mc(1);
   for( auto matched_hadTau : matched_hadTaus)

--- a/EvtWeightTools/src/Data_to_MC_CorrectionInterface_0l_4tau_trigger.cc
+++ b/EvtWeightTools/src/Data_to_MC_CorrectionInterface_0l_4tau_trigger.cc
@@ -49,6 +49,8 @@ Data_to_MC_CorrectionInterface_0l_4tau_trigger::getSF_triggerEff(TriggerSFsys ce
     if ( hadTau_recObj->filterBits() ) matched_hadTaus.push_back(hadTau_recObj);
   }
 
+  assert( matched_hadTaus.size() >= 2 );
+
   double prob_data(1);
   double prob_mc(1);
   for( auto matched_hadTau : matched_hadTaus)
@@ -64,20 +66,6 @@ Data_to_MC_CorrectionInterface_0l_4tau_trigger::getSF_triggerEff(TriggerSFsys ce
   return sf;
 }
  
-double
-Data_to_MC_CorrectionInterface_0l_4tau_trigger::getProb_tau(int tau_status,
-                                                            double eff_2tau_tauLeg) const
-{
-  double prob = 0.;
-  switch(tau_status)
-  {
-    case k2tau:    prob = eff_2tau_tauLeg;      break;
-    case kNot2tau: prob = 1. - eff_2tau_tauLeg; break;
-    default:       assert(0);
-  }
-  return prob;
-}
-
 bool
 Data_to_MC_CorrectionInterface_0l_4tau_trigger::check_triggerSFsys_opt(TriggerSFsys central_or_shift) const
 {

--- a/EvtWeightTools/src/Data_to_MC_CorrectionInterface_trigger_Base.cc
+++ b/EvtWeightTools/src/Data_to_MC_CorrectionInterface_trigger_Base.cc
@@ -74,6 +74,7 @@ Data_to_MC_CorrectionInterface_trigger_Base::setLeptons(const std::vector<const 
 void
 Data_to_MC_CorrectionInterface_trigger_Base::setHadTaus(const std::vector<const RecoHadTau *>& hadTaus)
 {
+  hadTau_recObjs.clear();
   for (auto hadTau : hadTaus)
   {
     if ( isDEBUG_ )

--- a/EvtWeightTools/src/Data_to_MC_CorrectionInterface_trigger_Base.cc
+++ b/EvtWeightTools/src/Data_to_MC_CorrectionInterface_trigger_Base.cc
@@ -6,7 +6,7 @@
 #include "TallinnNtupleProducer/Objects/interface/RecoHadTau.h"                                 // RecoHadTau
 #include "TallinnNtupleProducer/Objects/interface/RecoLepton.h"                                 // RecoLepton
 #include "TallinnNtupleProducer/CommonTools/interface/hadTauDefinitions.h"                      // get_tau_id_enum(), get_tau_id_wp_str()
-
+#include "TallinnNtupleProducer/EvtWeightTools/interface/data_to_MC_corrections_auxFunctions.h" // aux::
 #include "TString.h"                                                                            // Form()
 
 #include <assert.h>                                                                             // assert()
@@ -74,36 +74,12 @@ Data_to_MC_CorrectionInterface_trigger_Base::setLeptons(const std::vector<const 
 void
 Data_to_MC_CorrectionInterface_trigger_Base::setHadTaus(const std::vector<const RecoHadTau *>& hadTaus)
 {
-  if(! hadTaus.empty())
+  for (auto hadTau : hadTaus)
   {
-    hadTau1_pt_ = hadTaus[0]->pt();
-    hadTau1_eta_ = hadTaus[0]->eta();
-    hadTau1_phi_ = hadTaus[0]->phi();
-    hadTau1_decayMode_ = hadTaus[0]->decayMode();
-  }
-
-  if ( hadTaus.size() >1 )
-  {
-    hadTau2_pt_ = hadTaus[1]->pt();
-    hadTau2_eta_ = hadTaus[1]->eta();
-    hadTau2_phi_ = hadTaus[1]->phi();
-    hadTau2_decayMode_ = hadTaus[1]->decayMode();
-  }
-
-  if ( hadTaus.size() >2 )
-  {
-    hadTau3_pt_ = hadTaus[2]->pt();
-    hadTau3_eta_ = hadTaus[2]->eta();
-    hadTau3_phi_ = hadTaus[2]->phi();
-    hadTau3_decayMode_ = hadTaus[2]->decayMode();
-  }
-  
-  if ( hadTaus.size() >3 )
-  {
-    hadTau4_pt_ = hadTaus[3]->pt();
-    hadTau4_eta_ = hadTaus[3]->eta();
-    hadTau4_phi_ = hadTaus[3]->phi();
-    hadTau4_decayMode_ = hadTaus[3]->decayMode();
+    if ( isDEBUG_ )
+      std::cout << "hadTau pt: " << hadTau->pt() << "\t eta: " << hadTau->eta() << "\t decayMode: " << hadTau->decayMode() << std::endl;
+    if ( std::fabs(hadTau->eta()) <= 2.1 && aux::hasDecayMode(allowedDecayModes_, hadTau->decayMode()))
+    hadTau_recObjs.push_back(hadTau);
   }
 }
 


### PR DESCRIPTION
This is related to the [issue](https://github.com/HEP-KBFI/TallinnNtupleProducer/issues/24). I guess we can simply check the filter bits of reco object to decide whether they are matched with trigger objects and if yes, consider only those reco objects to calculate sf. If it is fine, I'll check for 1l_3tau trigger also, currently implemented only for 4tau trigger case